### PR TITLE
Adds compiler flag to avoid build errors if no iOS module is installed

### DIFF
--- a/AppleAuth/Editor/ProjectCapabilityManagerExtension.cs
+++ b/AppleAuth/Editor/ProjectCapabilityManagerExtension.cs
@@ -1,3 +1,5 @@
+#if UNITY_IOS
+
 using System;
 using System.Reflection;
 using UnityEditor.iOS.Xcode;
@@ -50,3 +52,5 @@ namespace AppleAuth.Editor
         }
     }
 }
+
+#endif

--- a/AppleAuthSampleProject/Assets/AppleAuthSample/Editor/SignInWithApplePostprocessor.cs
+++ b/AppleAuthSampleProject/Assets/AppleAuthSample/Editor/SignInWithApplePostprocessor.cs
@@ -1,3 +1,5 @@
+#if UNITY_IOS
+
 using AppleAuth.Editor;
 using UnityEditor;
 using UnityEditor.Callbacks;
@@ -27,5 +29,6 @@ namespace AppleAuthSample.Editor
             manager.WriteToFile();
         }
     }
-    
 }
+
+#endif


### PR DESCRIPTION
Solves #6 