### PR TITLE
Include 'using AppleAuth.Editor' in programmatic xcode project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The provided extension method is `AddSignInWithApple`. No arguments are required
 
 Sample code:
 ```csharp
+using AppleAuth.Editor;
+
 public static class SignInWithApplePostprocessor
 {
     [PostProcessBuild(1)]


### PR DESCRIPTION
We should include 'using AppleAuth.Editor' in the programmatic xcode project setup example to avoid confusion why the extension method 'AddSignInWithApple()' can not be found.

I at least wasted a few minutes figuring out how this dependency is resolved and found the solution by checking the example project. I think we could avoid that other people have to do the same.