### PR TITLE
Firebase Unity Authentication Support

### DIFF
--- a/AppleAuth/IOS/AppleAuthManager.cs
+++ b/AppleAuth/IOS/AppleAuthManager.cs
@@ -25,6 +25,20 @@ namespace AppleAuth.IOS
             }
         }
 
+
+        public string RawNonce
+        {
+            get
+            {
+#if UNITY_IOS && !UNITY_EDITOR
+                return PInvoke.AppleAuth_IOS_GetRawNonce();
+#else
+                return null;
+#endif
+            }
+        }
+
+
         public AppleAuthManager(IPayloadDeserializer payloadDeserializer, IMessageHandlerScheduler scheduler)
         {
 #if UNITY_IOS && !UNITY_EDITOR
@@ -129,11 +143,15 @@ namespace AppleAuth.IOS
 #endif
         }
 
+
 #if UNITY_IOS && !UNITY_EDITOR
         private static class PInvoke
         {
             [System.Runtime.InteropServices.DllImport("__Internal")]
             public static extern bool AppleAuth_IOS_IsCurrentPlatformSupported();
+
+			[System.Runtime.InteropServices.DllImport("__Internal")]
+            public static extern string AppleAuth_IOS_GetRawNonce();
             
             [System.Runtime.InteropServices.DllImport("__Internal")]
             public static extern void AppleAuth_IOS_GetCredentialState(uint requestId, string userId);

--- a/AppleAuth/IOS/IAppleAuthManager.cs
+++ b/AppleAuth/IOS/IAppleAuthManager.cs
@@ -7,7 +7,8 @@ namespace AppleAuth.IOS
     public interface IAppleAuthManager
     {
         bool IsCurrentPlatformSupported { get; }
-        
+        string RawNonce { get; }
+
         void QuickLogin(Action<ICredential> successCallback, Action<IAppleError> errorCallback);
         void LoginWithAppleId(LoginOptions loginOptions, Action<ICredential> successCallback, Action<IAppleError> errorCallback);
         void GetCredentialState(string userId, Action<CredentialState> successCallback, Action<IAppleError> errorCallback);

--- a/AppleAuth/IOS/ObjC/AppleAuthManager.m
+++ b/AppleAuth/IOS/ObjC/AppleAuthManager.m
@@ -25,6 +25,7 @@
 #import "AppleAuthManager.h"
 #import "NativeMessageHandler.h"
 #import "AppleAuthSerializer.h"
+#import <CommonCrypto/CommonDigest.h>
 
 #pragma mark - AppleAuthManager Implementation
 
@@ -37,6 +38,9 @@
 @property (nonatomic, strong) ASAuthorizationPasswordProvider *passwordProvider;
 @property (nonatomic, strong) NSObject *credentialsRevokedObserver;
 @property (nonatomic, strong) NSMutableDictionary<NSValue *, NSNumber *> *authorizationsInProgress;
+
+@property (nonatomic, strong) NSString *currentNonce;
+
 @end
 
 @implementation AppleAuthManager
@@ -69,7 +73,11 @@
 
 - (void) quickLogin:(uint)requestId
 {
+	NSString *nonce = [self randomNonce:32];
+	self.currentNonce = nonce;
+	
     ASAuthorizationAppleIDRequest *appleIDRequest = [[self appleIdProvider] createRequest];
+	appleIDRequest.nonce = [self stringBySha256HashingString:nonce];
     ASAuthorizationPasswordRequest *keychainRequest = [[self passwordProvider] createRequest];
     
     ASAuthorizationController *authorizationController = [[ASAuthorizationController alloc] initWithAuthorizationRequests:@[appleIDRequest, keychainRequest]];
@@ -78,7 +86,11 @@
 
 - (void) loginWithAppleId:(uint)requestId withOptions:(AppleAuthManagerLoginOptions)options
 {
+	NSString *nonce = [self randomNonce:32];
+	self.currentNonce = nonce;
+	
     ASAuthorizationAppleIDRequest *request = [[self appleIdProvider] createRequest];
+	request.nonce = [self stringBySha256HashingString:nonce];
     NSMutableArray *scopes = [NSMutableArray array];
     
     if (options & AppleAuthManagerIncludeName)
@@ -146,18 +158,69 @@
     [authorizationController performRequests];
 }
 
+
+- (NSString *)randomNonce:(NSInteger)length {
+  NSAssert(length > 0, @"Expected nonce to have positive length");
+  NSString *characterSet = @"0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._";
+  NSMutableString *result = [NSMutableString string];
+  NSInteger remainingLength = length;
+
+  while (remainingLength > 0) {
+    NSMutableArray *randoms = [NSMutableArray arrayWithCapacity:16];
+    for (NSInteger i = 0; i < 16; i++) {
+      uint8_t random = 0;
+      int errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random);
+      NSAssert(errorCode == errSecSuccess, @"Unable to generate nonce: OSStatus %i", errorCode);
+
+      [randoms addObject:@(random)];
+    }
+
+    for (NSNumber *random in randoms) {
+      if (remainingLength == 0) {
+        break;
+      }
+
+      if (random.unsignedIntValue < characterSet.length) {
+        unichar character = [characterSet characterAtIndex:random.unsignedIntValue];
+        [result appendFormat:@"%C", character];
+        remainingLength--;
+      }
+    }
+  }
+  return result;
+}
+
+
+- (NSString *)stringBySha256HashingString:(NSString *)input {
+  const char *string = [input UTF8String];
+  unsigned char result[CC_SHA256_DIGEST_LENGTH];
+  CC_SHA256(string, (CC_LONG)strlen(string), result);
+
+  NSMutableString *hashed = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+  for (NSInteger i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+    [hashed appendFormat:@"%02x", result[i]];
+  }
+  return hashed;
+}
+
+
+
 #pragma mark ASAuthorizationControllerDelegate protocol implementation
 
 - (void) authorizationController:(ASAuthorizationController *)controller didCompleteWithAuthorization:(ASAuthorization *)authorization
 {
     NSValue *authControllerAsKey = [NSValue valueWithNonretainedObject:controller];
     NSNumber *requestIdNumber = [[self authorizationsInProgress] objectForKey:authControllerAsKey];
+	
     if (requestIdNumber)
     {
         NSDictionary *appleIdCredentialDictionary = nil;
         NSDictionary *passwordCredentialDictionary = nil;
         if ([[authorization credential] isKindOfClass:[ASAuthorizationAppleIDCredential class]])
         {
+			NSString *rawNonce = self.currentNonce;
+			NSAssert(rawNonce != nil, @"Invalid state: A login callback was received, but no login request was sent.");
+
             appleIdCredentialDictionary = [AppleAuthSerializer dictionaryForASAuthorizationAppleIDCredential:(ASAuthorizationAppleIDCredential *)[authorization credential]];
         }
         else if ([[authorization credential] isKindOfClass:[ASPasswordCredential class]])
@@ -292,3 +355,28 @@ void AppleAuth_IOS_SendUnsupportedPlatformLoginResponse(uint requestId)
     
     [[NativeMessageHandler defaultHandler] sendNativeMessageForDictionary:responseDictionary forRequestId:requestId];
 }
+
+
+// Helper method to create C string copy
+char* MakeStringCopy (const char* string)
+{
+	if (string == NULL)
+		return NULL;
+	
+	char* res = (char*)malloc(strlen(string) + 1);
+	strcpy(res, string);
+	return res;
+}
+
+
+const char* AppleAuth_IOS_GetRawNonce()
+{
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 || __TV_OS_VERSION_MAX_ALLOWED >= 130000 || __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+	if (@available(iOS 13.0, tvOS 13.0, macOS 10.15, *))
+		// By default mono string marshaler creates .Net string for returned UTF-8 C string
+		// and calls free for returned value, thus returned strings should be allocated on heap
+		return MakeStringCopy([[[AppleAuthManager sharedManager] currentNonce] UTF8String]);
+#endif
+	return NULL;
+}
+


### PR DESCRIPTION
Apple Signin now supports Authentication with Firebase Unity. Native code generates a "nonce" that is sent with the Apple SignIn request and is accessible through AppleAuthManager.RawNonce. This is necessary for the new OAuthProvider.GetCredential() method available in Firebase Unity 6.10.0

Firebase 6.10.0 was released on January 30th 2020. Before this release, it was impossible to grab SignInWithApple Credentials in Unity code. I referenced the [Firebase Auth documentation for iOS](https://firebase.google.com/docs/auth/ios/apple?authuser=0) when implementing the native code. 

This is my first pull request and what I'm submitting is the "quick and dirty" pass that got my code running. I am open to making tweaks to code style.

Another headache for me was understanding how to decode the IdentityToken into something Firebase would parse and accept. The wrong way was taking the byte[] of IdentityToken and using Convert.ToBase64String(). The correct way was explicitly converting to a UTF-8 string. I feel like this would be a valuable "gotcha" to mention on the FAQ.

`string token = System.Text.Encoding.UTF8.GetString(appleIDCredential.IdentityToken)`