### PR TITLE
Adds support for Nonce in the Authorization Requests

### DIFF
--- a/AppleAuth/IOS/AppleAuthLoginArgs.cs
+++ b/AppleAuth/IOS/AppleAuthLoginArgs.cs
@@ -1,0 +1,18 @@
+using AppleAuth.IOS.Enums;
+
+namespace AppleAuth.IOS
+{
+    public struct AppleAuthLoginArgs
+    {
+        public readonly LoginOptions Options;
+        public readonly string Nonce;
+    
+        public AppleAuthLoginArgs(
+            LoginOptions options,
+            string nonce = null)
+        {
+            this.Options = options;
+            this.Nonce = nonce;
+        }
+    }
+}

--- a/AppleAuth/IOS/AppleAuthLoginArgs.cs.meta
+++ b/AppleAuth/IOS/AppleAuthLoginArgs.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e51f5ce36b7f479e88a589415b3c01b7
+timeCreated: 1580761559

--- a/AppleAuth/IOS/AppleAuthManager.cs
+++ b/AppleAuth/IOS/AppleAuthManager.cs
@@ -143,10 +143,10 @@ namespace AppleAuth.IOS
             public static extern void AppleAuth_IOS_GetCredentialState(uint requestId, string userId);
 
             [System.Runtime.InteropServices.DllImport("__Internal")]
-            public static extern void AppleAuth_IOS_LoginWithAppleId(uint requestId, int loginOptions, string nonce);
+            public static extern void AppleAuth_IOS_LoginWithAppleId(uint requestId, int loginOptions, string nonceCStr);
             
             [System.Runtime.InteropServices.DllImport("__Internal")]
-            public static extern void AppleAuth_IOS_QuickLogin(uint requestId, string nonce);
+            public static extern void AppleAuth_IOS_QuickLogin(uint requestId, string nonceCStr);
             
             [System.Runtime.InteropServices.DllImport("__Internal")]
             public static extern void AppleAuth_IOS_RegisterCredentialsRevokedCallbackId(uint callbackId);

--- a/AppleAuth/IOS/AppleAuthManager.cs
+++ b/AppleAuth/IOS/AppleAuthManager.cs
@@ -34,10 +34,12 @@ namespace AppleAuth.IOS
         }
         
         public void QuickLogin(
+            AppleAuthQuickLoginArgs quickLoginArgs,
             Action<ICredential> successCallback,
             Action<IAppleError> errorCallback)
         {
 #if UNITY_IOS && !UNITY_EDITOR
+            var nonce = quickLoginArgs.Nonce;
             var requestId = NativeMessageHandler.AddMessageCallback(
                 this._scheduler,
                 true,
@@ -52,18 +54,20 @@ namespace AppleAuth.IOS
                         successCallback(response.AppleIDCredential);
                 });
 
-            PInvoke.AppleAuth_IOS_QuickLogin(requestId);
+            PInvoke.AppleAuth_IOS_QuickLogin(requestId, nonce);
 #else
             throw new Exception("Apple Auth is only supported for iOS 13.0 onwards");
 #endif
         }
         
         public void LoginWithAppleId(
-            LoginOptions loginOptions,
+            AppleAuthLoginArgs loginArgs,
             Action<ICredential> successCallback,
             Action<IAppleError> errorCallback)
         {
 #if UNITY_IOS && !UNITY_EDITOR
+            var loginOptions = loginArgs.Options;
+            var nonce = loginArgs.Nonce;
             var requestId = NativeMessageHandler.AddMessageCallback(
                 this._scheduler,
                 true,
@@ -76,7 +80,7 @@ namespace AppleAuth.IOS
                         successCallback(response.AppleIDCredential);
                 });
             
-            PInvoke.AppleAuth_IOS_LoginWithAppleId(requestId, (int)loginOptions);
+            PInvoke.AppleAuth_IOS_LoginWithAppleId(requestId, (int)loginOptions, nonce);
 #else
             throw new Exception("Apple Auth is only supported for iOS 13.0 onwards");
 #endif
@@ -139,10 +143,10 @@ namespace AppleAuth.IOS
             public static extern void AppleAuth_IOS_GetCredentialState(uint requestId, string userId);
 
             [System.Runtime.InteropServices.DllImport("__Internal")]
-            public static extern void AppleAuth_IOS_LoginWithAppleId(uint requestId, int loginOptions);
+            public static extern void AppleAuth_IOS_LoginWithAppleId(uint requestId, int loginOptions, string nonce);
             
             [System.Runtime.InteropServices.DllImport("__Internal")]
-            public static extern void AppleAuth_IOS_QuickLogin(uint requestId);
+            public static extern void AppleAuth_IOS_QuickLogin(uint requestId, string nonce);
             
             [System.Runtime.InteropServices.DllImport("__Internal")]
             public static extern void AppleAuth_IOS_RegisterCredentialsRevokedCallbackId(uint callbackId);

--- a/AppleAuth/IOS/AppleAuthQuickLoginArgs.cs
+++ b/AppleAuth/IOS/AppleAuthQuickLoginArgs.cs
@@ -1,0 +1,12 @@
+namespace AppleAuth.IOS
+{
+    public struct AppleAuthQuickLoginArgs
+    {
+        public readonly string Nonce;
+
+        public AppleAuthQuickLoginArgs(string nonce = null)
+        {
+            this.Nonce = nonce;
+        }
+    }
+}

--- a/AppleAuth/IOS/AppleAuthQuickLoginArgs.cs.meta
+++ b/AppleAuth/IOS/AppleAuthQuickLoginArgs.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0295b0e4e9184f85a2dab62bdd170cc9
+timeCreated: 1580761597

--- a/AppleAuth/IOS/IAppleAuthManager.cs
+++ b/AppleAuth/IOS/IAppleAuthManager.cs
@@ -8,8 +8,8 @@ namespace AppleAuth.IOS
     {
         bool IsCurrentPlatformSupported { get; }
         
-        void QuickLogin(Action<ICredential> successCallback, Action<IAppleError> errorCallback);
-        void LoginWithAppleId(LoginOptions loginOptions, Action<ICredential> successCallback, Action<IAppleError> errorCallback);
+        void QuickLogin(AppleAuthQuickLoginArgs quickLoginArgs, Action<ICredential> successCallback, Action<IAppleError> errorCallback);
+        void LoginWithAppleId(AppleAuthLoginArgs loginArgs, Action<ICredential> successCallback, Action<IAppleError> errorCallback);
         void GetCredentialState(string userId, Action<CredentialState> successCallback, Action<IAppleError> errorCallback);
         void SetCredentialsRevokedCallback(Action<string> credentialsRevokedCallback);
     }

--- a/AppleAuth/IOS/ObjC/AppleAuthManager.h
+++ b/AppleAuth/IOS/ObjC/AppleAuthManager.h
@@ -39,8 +39,8 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
 
 + (instancetype) sharedManager;
 
-- (void) quickLogin:(uint)requestId;
-- (void) loginWithAppleId:(uint)requestId withOptions:(AppleAuthManagerLoginOptions)options;
+- (void) quickLogin:(uint)requestId withNonce:(NSString *)nonce;
+- (void) loginWithAppleId:(uint)requestId withOptions:(AppleAuthManagerLoginOptions)options andNonce:(NSString *)nonce;
 - (void) getCredentialStateForUser:(NSString *)userId withRequestId:(uint)requestId;
 - (void) registerCredentialsRevokedCallbackForRequestId:(uint)requestId;
 
@@ -50,8 +50,8 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
 
 bool AppleAuth_IOS_IsCurrentPlatformSupported();
 void AppleAuth_IOS_GetCredentialState(uint requestId, const char* userId);
-void AppleAuth_IOS_LoginWithAppleId(uint requestId, int options);
-void AppleAuth_IOS_LoginSilently(uint requestId);
+void AppleAuth_IOS_LoginWithAppleId(uint requestId, int options, const char* _Nullable nonceCStr);
+void AppleAuth_IOS_QuickLogin(uint requestId, const char* _Nullable nonceCStr);
 void AppleAuth_IOS_RegisterCredentialsRevokedCallbackId(uint requestId);
 void AppleAuth_IOS_SendUnsupportedPlatformCredentialStatusResponse(uint requestId);
 void AppleAuth_IOS_SendUnsupportedPlatformLoginResponse(uint requestId);

--- a/AppleAuthSampleProject/Assets/AppleAuthSample/MainMenu.cs
+++ b/AppleAuthSampleProject/Assets/AppleAuthSample/MainMenu.cs
@@ -155,8 +155,11 @@ public class MainMenu : MonoBehaviour
     
     private void AttemptQuickLogin()
     {
+        var quickLoginArgs = new AppleAuthQuickLoginArgs();
+        
         // Quick login should succeed if the credential was authorized before and not revoked
         this._appleAuthManager.QuickLogin(
+            quickLoginArgs,
             credential =>
             {
                 // If it's an Apple credential, save the user ID, for later logins
@@ -178,8 +181,10 @@ public class MainMenu : MonoBehaviour
     
     private void SignInWithApple()
     {
+        var loginArgs = new AppleAuthLoginArgs(LoginOptions.IncludeEmail | LoginOptions.IncludeFullName);
+        
         this._appleAuthManager.LoginWithAppleId(
-            LoginOptions.IncludeEmail | LoginOptions.IncludeFullName,
+            loginArgs,
             credential =>
             {
                 // If a sign in with apple succeeds, we should have obtained the credential with the user id, name, and email, save it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] Future v1.1.0
+## [Unreleased] v1.1.0
 ### Added
 - Adds a CHANGELOG.md file
 - Adds new v2 diagram files (`.drawio` and `.png`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,16 @@
 ### Added
 - Adds a CHANGELOG.md file
 - Adds new v2 diagram files (`.drawio` and `.png`)
+- Adds structure containing arguments for Quick Login `AppleAuthQuickLoginArgs`.
+The structure contains an optional `Nonce`.
+- Adds structure containing arguments for Normal Login `AppleAuthLoginArgs`.
+The structure contains the mandatory `LoginOptions` an optional `Nonce`.
+- Adds support in native code to receive and set a `Nonce` for
+the Authorization Requests in both Quick Login and Sign in With Apple
 
 ### Changed
+- `QuickLogin` now requires a `AppleAuthQuickLoginArgs` to perform the call
+- `LoginWithAppleId` now requires a `AppleAuthLoginArgs` to perform the call
 - Updates main package file to include both `CHANGELOG.md` and `CHANGELOG.md.meta files`
 - Updates the sample project to better resemble the expected Apple flow
 - Updates README.md with up to date documentation

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 by **Daniel Lupiañez Casares**
 
+[CHANGELOG](./CHANGELOG.md)
+
 ![Release](https://img.shields.io/github/v/release/lupidan/apple-signin-unity?style=for-the-badge!)
 [![Stars](https://img.shields.io/github/stars/lupidan/apple-signin-unity.svg?style=social)](https://gitHub.com/lupidan/apple-signin-unity/stargazers/)
 [![Followers](https://img.shields.io/github/followers/lupidan.svg?style=social)](https://github.com/lupidan?tab=followers)
@@ -74,10 +76,15 @@ Sign in with Apple in order to get approved for the App Store, making it **manda
 - Customizable serialization (uses Unity default serialization, but you can add your own implementation)
 
 ## Installation
+
+> Current stable version is v1.0.0
+
 ### Option 1: Unity Package manager
+
 Available starting from Unity 2018.3.
 
-Just add this line to the `Packages/manifest.json` file of your Unity Project. It will make the v1.0.0 of the plugin available to use in your code to the latest master.
+Just add this line to the `Packages/manifest.json` file of your Unity Project:
+
 ```json
 "dependencies": {
     "com.lupidan.apple-signin-unity": "https://github.com/lupidan/apple-signin-unity.git#v1.0.0",

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Sign in with Apple in order to get approved for the App Store, making it **manda
 - Supports Quick login (including iTunes Keychain credentials).
 - Supports adding Sign In with Apple capability to Xcode project programatically in a PostBuild script.
 - Supports listening to Credentials Revoked notifications.
+- Supports setting custom Nonce for authorization requests when Signing In, and attempting a Quick Login.
 - NSError mapping so no details are missing.
 - NSPersonNameComponents support (for ALL different styles).
 - Customizable callback execution (Immediate or On Demand in an Update loop f.ex)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ by **Daniel Lupiañez Casares**
     + [Quick login](#quick-login)
     + [Checking credential status](#checking-credential-status)
     + [Listening to credentials revoked notification](#listening-to-credentials-revoked-notification)
+    + [Nonce support for Authorization Requests](#nonce-support-for-authorization-requests)
   * [FAQ](#faq)
     + [Does it support landscape orientations?](#does-it-support-landscape-orientations)
     + [How can I Logout? Does the plugin provide any Logout option?](#how-can-i-logout-does-the-plugin-provide-any-logout-option)
@@ -207,8 +208,10 @@ void Update()
 If you want to Sign In and request the Email and Full Name for a user, you can do it like this:
 
 ```csharp
+var loginArgs = new AppleAuthLoginArgs(LoginOptions.IncludeEmail | LoginOptions.IncludeFullName);
+
 this.appleAuthManager.LoginWithAppleId(
-    LoginOptions.IncludeEmail | LoginOptions.IncludeFullName,
+    loginArgs,
     credential =>
     {
         // Obtained credential, cast it to IAppleIDCredential
@@ -234,7 +237,10 @@ If the credentials were never given, or they were revoked, the Quick login will 
 ![Frameworks detail](./Img/QuickLogin.png)
 
 ```csharp
+var quickLoginArgs = new AppleAuthQuickLoginArgs();
+
 this.appleAuthManager.QuickLogin(
+    quickLoginArgs,
     credential =>
     {
         // Received a valid credential!
@@ -254,7 +260,7 @@ this.appleAuthManager.QuickLogin(
 
 Note that, if this succeeds, you will **ONLY** receive the Apple User ID (no email or name, even if it was previously requested).
 
-##### IOS Keychain Support
+#### IOS Keychain Support
 When performing a quick login, if the SDK detects [IOS Keychain credentials](https://developer.apple.com/documentation/security/keychain_services/keychain_items?language=objc) for your app, it will return those.
 
 Just cast the credential to `IPasswordCredential` to get the login details for the user.
@@ -311,6 +317,27 @@ To clear the callback, and stop listening to notifications, simply set it to `nu
 ```csharp
 this.appleAuthManager.SetCredentialsRevokedCallback(null);
 ```
+
+### Nonce support for Authorization Requests
+
+Both methods, `LoginWithAppleId` and `QuickLogin`, use a custom structure containing arguments for the authorization request.
+
+An optional `Nonce` can be set for both structures when constructing them:
+
+```csharp
+// Your custom Nonce string
+var yourCustomNonce = "YOURCUSTOMNONCEFORTHEAUTHORIZATIONREQUEST";
+
+// Arguments for a normal Sign In With Apple Request
+var loginArgs = new AppleAuthLoginArgs(
+    LoginOptions.IncludeEmail | LoginOptions.IncludeFullName,
+    yourCustomNonce);
+
+// Arguments for a Quick Login
+var quickLoginArgs = new AppleAuthQuickLoginArgs(yourCustomNonce);
+```
+
+This is useful for services that provide a built in solution for **Sign In With Apple**, like [Firebase](https://firebase.google.com/docs/auth/ios/apple?authuser=0)
 
 ## FAQ
 + [Does it support landscape orientations](#does-it-support-landscape-orientations)


### PR DESCRIPTION
### Added
- Adds structure containing arguments for Quick Login `AppleAuthQuickLoginArgs`.
The structure contains an optional `Nonce`.
- Adds structure containing arguments for Normal Login `AppleAuthLoginArgs`.
The structure contains the mandatory `LoginOptions` an optional `Nonce`.
- Adds support in native code to receive and set a `Nonce` for
the Authorization Requests in both Quick Login and Sign in With Apple

### Changed
- `QuickLogin` now requires a `AppleAuthQuickLoginArgs` to perform the call
- `LoginWithAppleId` now requires a `AppleAuthLoginArgs` to perform the call