### PR TITLE
Fix possible name conflicts with Unity 2019.3

### DIFF
--- a/AppleAuth/Editor/ProjectCapabilityManagerExtension.cs
+++ b/AppleAuth/Editor/ProjectCapabilityManagerExtension.cs
@@ -13,7 +13,13 @@ namespace AppleAuth.Editor
         private const string AuthenticationServicesFramework = "AuthenticationServices.framework";
         private const BindingFlags NonPublicInstanceBinding = BindingFlags.NonPublic | BindingFlags.Instance;
 
-        public static void AddSignInWithApple(this ProjectCapabilityManager manager)
+        /// <summary>
+        /// Extension method for ProjectCapabilityManager to add the Sign In With Apple capability in compatibility mode.
+        /// In particular, adds the AuthenticationServices.framework as an Optional framework, preventing crashes in
+        /// iOS versions previous to 13.0
+        /// </summary>
+        /// <param name="manager">The manager to use when adding the Sign In With Apple capability.</param>
+        public static void AddSignInWithAppleWithCompatibility(this ProjectCapabilityManager manager)
         {
             var managerType = typeof(ProjectCapabilityManager);
             var capabilityTypeType = typeof(PBXCapabilityType);

--- a/AppleAuthSampleProject/Assets/AppleAuthSample/Editor/SignInWithApplePostprocessor.cs
+++ b/AppleAuthSampleProject/Assets/AppleAuthSample/Editor/SignInWithApplePostprocessor.cs
@@ -25,7 +25,7 @@ namespace AppleAuthSample.Editor
 #else
             var manager = new ProjectCapabilityManager(projectPath, "Entitlements.entitlements", PBXProject.GetUnityTargetName());
 #endif
-            manager.AddSignInWithApple();
+            manager.AddSignInWithAppleWithCompatibility();
             manager.WriteToFile();
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Adds details to install the plugin with ![OpenUPM](https://openupm.com/) in `README.md`
 
 ### Changed
+- Renamed plugin´s extension method for `ProjectCapabilityManager` to avoid conflicts with the method added in Unity 2019.3. New method name is `AddSignInWithAppleWithCompatibility`.
 - Namespace `AppleAuth.IOS.NativeMessages` becomes `AppleAuth.NativeMessages`
 - Modified slightly implementation for Person name formatting
 - Modified native implementation of AppleAuthManager to support macOS

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ public static class SignInWithApplePostprocessor
 #endif
         
         // Adds required Entitlements entry, and framework programatically
-        manager.AddSignInWithApple();
+        // using extension method provided with the plugin.
+        manager.AddSignInWithAppleWithCompatibility();
         
         manager.WriteToFile();
     }


### PR DESCRIPTION
Unity introduced a method for `ProjectCapabilityManager` with the same name as the extension method provided by the plugin (`AddSignInWithApple`). This can easily lead to post processing builds using the Unity method instead of the extension method without even knowing about it.

Unity's implementation adds `AuthenticationServices.framework` method as **Mandatory**, which can lead to crashes in iOS versions previous to 13.0

On the other hand, the extension method provided by the plugin adds the `AuthenticationServices.framework` as Optional, avoiding those possible crashes.

The extension method was renamed to `AddSignInWithAppleWithCompatibility` allowing a clear distinction between both.

Example code was also updated.