### PR TITLE
Fix postprocessing for Unity 2019.3

### DIFF
--- a/AppleAuth/Editor/ProjectCapabilityManagerExtension.cs
+++ b/AppleAuth/Editor/ProjectCapabilityManagerExtension.cs
@@ -21,7 +21,6 @@ namespace AppleAuth.Editor
         /// <param name="manager">The manager for the main target to use when adding the Sign In With Apple capability.</param>
         /// <param name="unityFrameworkTargetGuid">The GUID for the UnityFramework target. If null, it will use the main target GUID.</param>
         public static void AddSignInWithAppleWithCompatibility(this ProjectCapabilityManager manager, string unityFrameworkTargetGuid = null)
-
         {
             var managerType = typeof(ProjectCapabilityManager);
             var capabilityTypeType = typeof(PBXCapabilityType);
@@ -53,9 +52,11 @@ namespace AppleAuth.Editor
             if (project != null)
             {
                 var mainTargetGuid = targetGuidField.GetValue(manager) as string;
-                var capabilityType = constructorInfo.Invoke(new object[] { "com.apple.developer.applesignin.custom", true, null, false }) as PBXCapabilityType;
-                project.AddFrameworkToProject(unityFrameworkTargetGuid ?? mainTargetGuid, AuthenticationServicesFramework, true);
-                project.AddCapability(mainTargetGuid, capabilityType, entitlementFilePath);
+                var capabilityType = constructorInfo.Invoke(new object[] { "com.apple.developer.applesignin.custom", true, string.Empty, true }) as PBXCapabilityType;
+
+                var targetGuidToAddFramework = unityFrameworkTargetGuid ?? mainTargetGuid;
+                project.AddFrameworkToProject(targetGuidToAddFramework, AuthenticationServicesFramework, true);
+                project.AddCapability(mainTargetGuid, capabilityType, entitlementFilePath, false);
             }
         }
     }

--- a/AppleAuth/Editor/ProjectCapabilityManagerExtension.cs
+++ b/AppleAuth/Editor/ProjectCapabilityManagerExtension.cs
@@ -18,8 +18,10 @@ namespace AppleAuth.Editor
         /// In particular, adds the AuthenticationServices.framework as an Optional framework, preventing crashes in
         /// iOS versions previous to 13.0
         /// </summary>
-        /// <param name="manager">The manager to use when adding the Sign In With Apple capability.</param>
-        public static void AddSignInWithAppleWithCompatibility(this ProjectCapabilityManager manager)
+        /// <param name="manager">The manager for the main target to use when adding the Sign In With Apple capability.</param>
+        /// <param name="unityFrameworkTargetGuid">The GUID for the UnityFramework target. If null, it will use the main target GUID.</param>
+        public static void AddSignInWithAppleWithCompatibility(this ProjectCapabilityManager manager, string unityFrameworkTargetGuid = null)
+
         {
             var managerType = typeof(ProjectCapabilityManager);
             var capabilityTypeType = typeof(PBXCapabilityType);
@@ -50,10 +52,10 @@ namespace AppleAuth.Editor
             var project = projectField.GetValue(manager) as PBXProject;
             if (project != null)
             {
-                var targetGuid = targetGuidField.GetValue(manager) as string;
-                var capabilityType = constructorInfo.Invoke(new object[] { "com.apple.signin", true, AuthenticationServicesFramework, true }) as PBXCapabilityType;
-                project.AddCapability(targetGuid, capabilityType, entitlementFilePath, false);
-                project.AddFrameworkToProject(targetGuid, AuthenticationServicesFramework, true);
+                var mainTargetGuid = targetGuidField.GetValue(manager) as string;
+                var capabilityType = constructorInfo.Invoke(new object[] { "com.apple.developer.applesignin.custom", true, null, false }) as PBXCapabilityType;
+                project.AddFrameworkToProject(unityFrameworkTargetGuid ?? mainTargetGuid, AuthenticationServicesFramework, true);
+                project.AddCapability(mainTargetGuid, capabilityType, entitlementFilePath);
             }
         }
     }

--- a/AppleAuthSampleProject/Assets/AppleAuthSample/Editor/SignInWithApplePostprocessor.cs
+++ b/AppleAuthSampleProject/Assets/AppleAuthSample/Editor/SignInWithApplePostprocessor.cs
@@ -22,11 +22,13 @@ namespace AppleAuthSample.Editor
             var project = new PBXProject();
             project.ReadFromString(System.IO.File.ReadAllText(projectPath));
             var manager = new ProjectCapabilityManager(projectPath, "Entitlements.entitlements", null, project.GetUnityMainTargetGuid());
+            manager.AddSignInWithAppleWithCompatibility(project.GetUnityFrameworkTargetGuid());
+            manager.WriteToFile();
 #else
             var manager = new ProjectCapabilityManager(projectPath, "Entitlements.entitlements", PBXProject.GetUnityTargetName());
-#endif
             manager.AddSignInWithAppleWithCompatibility();
             manager.WriteToFile();
+#endif
         }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Adds details to install the plugin with ![OpenUPM](https://openupm.com/) in `README.md`
 
 ### Changed
+- Fixes PostProcessing for Unity 2019.3
 - Renamed plugin´s extension method for `ProjectCapabilityManager` to avoid conflicts with the method added in Unity 2019.3. New method name is `AddSignInWithAppleWithCompatibility`.
 - Namespace `AppleAuth.IOS.NativeMessages` becomes `AppleAuth.NativeMessages`
 - Modified slightly implementation for Person name formatting

--- a/README.md
+++ b/README.md
@@ -161,22 +161,16 @@ public static class SignInWithApplePostprocessor
         
         // Adds entitlement depending on the Unity version used
 #if UNITY_2019_3_OR_NEWER
-        
-        PBXProject project = new PBXProject();
-        project.ReadFromString(File.ReadAllText(projectPath));
-        var manager = new ProjectCapabilityManager(projectPath, "Entitlements.entitlements", null, project.GetUnityMainTargetGuid());
-        
+            var project = new PBXProject();
+            project.ReadFromString(System.IO.File.ReadAllText(projectPath));
+            var manager = new ProjectCapabilityManager(projectPath, "Entitlements.entitlements", null, project.GetUnityMainTargetGuid());
+            manager.AddSignInWithAppleWithCompatibility(project.GetUnityFrameworkTargetGuid());
+            manager.WriteToFile();
 #else
-        
-        var manager = new ProjectCapabilityManager(projectPath, "Entitlements.entitlements", PBXProject.GetUnityTargetName());
-        
+            var manager = new ProjectCapabilityManager(projectPath, "Entitlements.entitlements", PBXProject.GetUnityTargetName());
+            manager.AddSignInWithAppleWithCompatibility();
+            manager.WriteToFile();
 #endif
-        
-        // Adds required Entitlements entry, and framework programatically
-        // using extension method provided with the plugin.
-        manager.AddSignInWithAppleWithCompatibility();
-        
-        manager.WriteToFile();
     }
 }
 ```


### PR DESCRIPTION
On Unity 2019.3 two targets were added in the exported Xcode Project.

Frameworks need to be added to the UnityFramework target to compile

The entitlements need to be added to the main Unity-iPhone target to compile

Currently such case seems to not be properly supported by Unity´s ProjectCapabilityManager. Enhanced the method to allow such scenario.