### PR TITLE
Makes native classes internal to force interface use

### DIFF
--- a/AppleAuth/Native/AppleError.cs
+++ b/AppleAuth/Native/AppleError.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace AppleAuth.Native
 {
     [Serializable]
-    public class AppleError : IAppleError, ISerializationCallbackReceiver
+    internal class AppleError : IAppleError, ISerializationCallbackReceiver
     {
         public int _code;
         public string _domain;

--- a/AppleAuth/Native/AppleIDCredential.cs
+++ b/AppleAuth/Native/AppleIDCredential.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace AppleAuth.Native
 {
     [Serializable]
-    public class AppleIDCredential : IAppleIDCredential, ISerializationCallbackReceiver
+    internal class AppleIDCredential : IAppleIDCredential, ISerializationCallbackReceiver
     {
         public string _base64IdentityToken;
         public string _base64AuthorizationCode;

--- a/AppleAuth/Native/CredentialStateResponse.cs
+++ b/AppleAuth/Native/CredentialStateResponse.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace AppleAuth.Native
 {
     [Serializable]
-    public class CredentialStateResponse : ICredentialStateResponse, ISerializationCallbackReceiver
+    internal class CredentialStateResponse : ICredentialStateResponse, ISerializationCallbackReceiver
     {
         public bool _success;
         public bool _hasCredentialState;

--- a/AppleAuth/Native/FullPersonName.cs
+++ b/AppleAuth/Native/FullPersonName.cs
@@ -4,7 +4,7 @@ using System;
 namespace AppleAuth.Native
 {
     [Serializable]
-    public class FullPersonName : PersonName, IPersonName
+    internal class FullPersonName : PersonName, IPersonName
     {
         public bool _hasPhoneticRepresentation;
         public PersonName _phoneticRepresentation;

--- a/AppleAuth/Native/LoginWithAppleIdResponse.cs
+++ b/AppleAuth/Native/LoginWithAppleIdResponse.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace AppleAuth.Native
 {
     [Serializable]
-    public class LoginWithAppleIdResponse : ILoginWithAppleIdResponse, ISerializationCallbackReceiver
+    internal class LoginWithAppleIdResponse : ILoginWithAppleIdResponse, ISerializationCallbackReceiver
     {
         public bool _success;
         public bool _hasAppleIdCredential;

--- a/AppleAuth/Native/PasswordCredential.cs
+++ b/AppleAuth/Native/PasswordCredential.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace AppleAuth.Native
 {
     [Serializable]
-    public class PasswordCredential : IPasswordCredential, ISerializationCallbackReceiver
+    internal class PasswordCredential : IPasswordCredential, ISerializationCallbackReceiver
     {
         public string _user;
         public string _password;

--- a/AppleAuth/Native/PersonName.cs
+++ b/AppleAuth/Native/PersonName.cs
@@ -1,9 +1,11 @@
+using System;
 using AppleAuth.Interfaces;
 using UnityEngine;
 
 namespace AppleAuth.Native
 {
-    public class PersonName : IPersonName, ISerializationCallbackReceiver
+    [Serializable]
+    internal class PersonName : IPersonName, ISerializationCallbackReceiver
     {
         public string _namePrefix;
         public string _givenName;

--- a/AppleAuthSampleProject/Assets/AppleAuthSample/GameMenuHandler.cs
+++ b/AppleAuthSampleProject/Assets/AppleAuthSample/GameMenuHandler.cs
@@ -40,10 +40,19 @@ public class GameMenuHandler
                 stringBuilder.AppendLine("<b>State:</b> " + appleIdCredential.State);
 
             if (appleIdCredential.IdentityToken != null)
-                stringBuilder.AppendLine("<b>Identity token:</b> " + appleIdCredential.IdentityToken.Length + " bytes");
+            {
+                var identityToken = Encoding.UTF8.GetString(appleIdCredential.IdentityToken, 0, appleIdCredential.IdentityToken.Length);
+                stringBuilder.AppendLine("<b>Identity token (" + appleIdCredential.IdentityToken.Length + " bytes)</b>");
+                stringBuilder.AppendLine(identityToken.Substring(0, 45) + "...");
+            }
 
             if (appleIdCredential.AuthorizationCode != null)
-                stringBuilder.AppendLine("<b>Authorization Code:</b> " + appleIdCredential.AuthorizationCode.Length + " bytes");
+            {
+                var authorizationCodeString = Encoding.UTF8.GetString(appleIdCredential.AuthorizationCode, 0, appleIdCredential.AuthorizationCode.Length);
+                stringBuilder.AppendLine("<b>Authorization Code (" + appleIdCredential.AuthorizationCode.Length + " bytes)</b>");
+                stringBuilder.AppendLine(authorizationCodeString.Substring(0, 45) + "...");
+            }
+
 
             if (appleIdCredential.AuthorizedScopes != null)
                 stringBuilder.AppendLine("<b>Authorized Scopes:</b> " + string.Join(", ", appleIdCredential.AuthorizedScopes));

--- a/AppleAuthSampleProject/Assets/AppleAuthSample/GameMenuHandler.cs
+++ b/AppleAuthSampleProject/Assets/AppleAuthSample/GameMenuHandler.cs
@@ -48,11 +48,10 @@ public class GameMenuHandler
 
             if (appleIdCredential.AuthorizationCode != null)
             {
-                var authorizationCodeString = Encoding.UTF8.GetString(appleIdCredential.AuthorizationCode, 0, appleIdCredential.AuthorizationCode.Length);
+                var authorizationCode = Encoding.UTF8.GetString(appleIdCredential.AuthorizationCode, 0, appleIdCredential.AuthorizationCode.Length);
                 stringBuilder.AppendLine("<b>Authorization Code (" + appleIdCredential.AuthorizationCode.Length + " bytes)</b>");
-                stringBuilder.AppendLine(authorizationCodeString.Substring(0, 45) + "...");
+                stringBuilder.AppendLine(authorizationCode.Substring(0, 45) + "...");
             }
-
 
             if (appleIdCredential.AuthorizedScopes != null)
                 stringBuilder.AppendLine("<b>Authorized Scopes:</b> " + string.Join(", ", appleIdCredential.AuthorizedScopes));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## [Unreleased]
 ### Added
 - Adds support to set the `State` when making a Login or a Quick Login request to sign in with Apple. 
-- Improves deserialization for the data. 
+- Improves deserialization for the data.
+
+### Changed
+- Makes the parsed classes `internal` to force the usage of the interfaces.
 
 ## [1.2.0] - 2020-05-16
 ### Added

--- a/README.md
+++ b/README.md
@@ -281,9 +281,33 @@ this.appleAuthManager.LoginWithAppleId(
     {
         // Obtained credential, cast it to IAppleIDCredential
         var appleIdCredential = credential as IAppleIDCredential;
-        // You should save the user ID somewhere in the device
-        // And now you have all the information to create/login a user in your system
-        PlayerPrefs.SetString(AppleUserIdKey, credential.User);
+        if (appleIdCredential != null)
+        {
+            // Apple User ID
+            // You should save the user ID somewhere in the device
+            var userId = appleIdCredential.User;
+            PlayerPrefs.SetString(AppleUserIdKey, userId);
+
+            // Email (Received ONLY in the first login)
+            var email = appleIdCredential.Email;
+
+            // Full name (Received ONLY in the first login)
+            var fullName = appleIdCredential.FullName
+
+            // Identity token
+            var identityToken = Encoding.UTF8.GetString(
+                appleIdCredential.IdentityToken,
+                0,
+                appleIdCredential.IdentityToken.Length);
+
+            // Authorization code
+            var authorizationCode = Encoding.UTF8.GetString(
+                    appleIdCredential.AuthorizationCode,
+                    0,
+                    appleIdCredential.AuthorizationCode.Length);
+
+            // And now you have all the information to create/login a user in your system
+        }
     },
     error =>
     {


### PR DESCRIPTION
### Changed
- Makes the parsed classes `internal` to force the usage of the interfaces.

This should avoid people mistakenly using the implementation classes.