### PR TITLE
Improves compatibility with lower C# versions

### DIFF
--- a/AppleAuth/Editor/ProjectCapabilityManagerExtension.cs
+++ b/AppleAuth/Editor/ProjectCapabilityManagerExtension.cs
@@ -54,7 +54,12 @@ namespace AppleAuth.Editor
                 var mainTargetGuid = targetGuidField.GetValue(manager) as string;
                 var capabilityType = constructorInfo.Invoke(new object[] { "com.apple.developer.applesignin.custom", true, string.Empty, true }) as PBXCapabilityType;
 
-                var targetGuidToAddFramework = unityFrameworkTargetGuid ?? mainTargetGuid;
+                var targetGuidToAddFramework = unityFrameworkTargetGuid;
+                if (targetGuidToAddFramework == null)
+                {
+                    targetGuidToAddFramework = mainTargetGuid;
+                }
+
                 project.AddFrameworkToProject(targetGuidToAddFramework, AuthenticationServicesFramework, true);
                 project.AddCapability(mainTargetGuid, capabilityType, entitlementFilePath, false);
             }

--- a/AppleAuth/Extensions/AppleErrorExtensions.cs
+++ b/AppleAuth/Extensions/AppleErrorExtensions.cs
@@ -6,7 +6,7 @@ namespace AppleAuth.Extensions
 {
     public static class AppleErrorExtensions
     {
-        public static AuthorizationErrorCode? GetAuthorizationErrorCode(this IAppleError error)
+        public static AuthorizationErrorCode GetAuthorizationErrorCode(this IAppleError error)
         {
             if (error.Domain == "com.apple.AuthenticationServices.AuthorizationError" &&
                 Enum.IsDefined(typeof(AuthorizationErrorCode), error.Code))
@@ -14,7 +14,7 @@ namespace AppleAuth.Extensions
                 return (AuthorizationErrorCode)error.Code;
             }
             
-            return null;
+            return AuthorizationErrorCode.Unknown;
         }
     }
 }

--- a/AppleAuth/Native/AppleError.cs
+++ b/AppleAuth/Native/AppleError.cs
@@ -7,12 +7,12 @@ namespace AppleAuth.Native
     [Serializable]
     internal class AppleError : IAppleError, ISerializationCallbackReceiver
     {
-        public int _code;
-        public string _domain;
-        public string _localizedDescription;
-        public string[] _localizedRecoveryOptions;
-        public string _localizedRecoverySuggestion;
-        public string _localizedFailureReason;
+        public int _code = 0;
+        public string _domain = null;
+        public string _localizedDescription = null;
+        public string[] _localizedRecoveryOptions = null;
+        public string _localizedRecoverySuggestion = null;
+        public string _localizedFailureReason = null;
         
         public int Code { get { return this._code; } }
         public string Domain { get { return this._domain; } }

--- a/AppleAuth/Native/AppleIDCredential.cs
+++ b/AppleAuth/Native/AppleIDCredential.cs
@@ -8,15 +8,15 @@ namespace AppleAuth.Native
     [Serializable]
     internal class AppleIDCredential : IAppleIDCredential, ISerializationCallbackReceiver
     {
-        public string _base64IdentityToken;
-        public string _base64AuthorizationCode;
-        public string _state;
-        public string _user;
-        public string[] _authorizedScopes;
-        public bool _hasFullName;
-        public FullPersonName _fullName;
-        public string _email;
-        public int _realUserStatus;
+        public string _base64IdentityToken = null;
+        public string _base64AuthorizationCode = null;
+        public string _state = null;
+        public string _user = null;
+        public string[] _authorizedScopes = null;
+        public bool _hasFullName = false;
+        public FullPersonName _fullName = null;
+        public string _email = null;
+        public int _realUserStatus = 0;
 
         private byte[] _identityToken;
         private byte[] _authorizationCode;

--- a/AppleAuth/Native/CredentialStateResponse.cs
+++ b/AppleAuth/Native/CredentialStateResponse.cs
@@ -8,11 +8,11 @@ namespace AppleAuth.Native
     [Serializable]
     internal class CredentialStateResponse : ICredentialStateResponse, ISerializationCallbackReceiver
     {
-        public bool _success;
-        public bool _hasCredentialState;
-        public bool _hasError;
-        public int _credentialState;
-        public AppleError _error;
+        public bool _success = false;
+        public bool _hasCredentialState = false;
+        public bool _hasError = false;
+        public int _credentialState = 0;
+        public AppleError _error = null;
 
         public bool Success { get { return this._success; } }
         public CredentialState CredentialState { get { return (CredentialState) this._credentialState; } }

--- a/AppleAuth/Native/FullPersonName.cs
+++ b/AppleAuth/Native/FullPersonName.cs
@@ -6,8 +6,8 @@ namespace AppleAuth.Native
     [Serializable]
     internal class FullPersonName : PersonName, IPersonName
     {
-        public bool _hasPhoneticRepresentation;
-        public PersonName _phoneticRepresentation;
+        public bool _hasPhoneticRepresentation = false;
+        public PersonName _phoneticRepresentation = null;
 
         public new IPersonName PhoneticRepresentation { get { return _phoneticRepresentation; } }
 

--- a/AppleAuth/Native/LoginWithAppleIdResponse.cs
+++ b/AppleAuth/Native/LoginWithAppleIdResponse.cs
@@ -7,13 +7,13 @@ namespace AppleAuth.Native
     [Serializable]
     internal class LoginWithAppleIdResponse : ILoginWithAppleIdResponse, ISerializationCallbackReceiver
     {
-        public bool _success;
-        public bool _hasAppleIdCredential;
-        public bool _hasPasswordCredential;
-        public bool _hasError;
-        public AppleIDCredential _appleIdCredential;
-        public PasswordCredential _passwordCredential;
-        public AppleError _error;
+        public bool _success = false;
+        public bool _hasAppleIdCredential = false;
+        public bool _hasPasswordCredential = false;
+        public bool _hasError = false;
+        public AppleIDCredential _appleIdCredential = null;
+        public PasswordCredential _passwordCredential = null;
+        public AppleError _error = null;
 
         public bool Success { get { return this._success; } }
         public IAppleError Error { get { return this._error; } }

--- a/AppleAuth/Native/PasswordCredential.cs
+++ b/AppleAuth/Native/PasswordCredential.cs
@@ -7,8 +7,8 @@ namespace AppleAuth.Native
     [Serializable]
     internal class PasswordCredential : IPasswordCredential, ISerializationCallbackReceiver
     {
-        public string _user;
-        public string _password;
+        public string _user = null;
+        public string _password = null;
         
         public string User { get { return this._user; } }
         public string Password { get { return this._password; } }

--- a/AppleAuth/Native/PersonName.cs
+++ b/AppleAuth/Native/PersonName.cs
@@ -7,12 +7,12 @@ namespace AppleAuth.Native
     [Serializable]
     internal class PersonName : IPersonName, ISerializationCallbackReceiver
     {
-        public string _namePrefix;
-        public string _givenName;
-        public string _middleName;
-        public string _familyName;
-        public string _nameSuffix;
-        public string _nickname;
+        public string _namePrefix = null;
+        public string _givenName = null;
+        public string _middleName = null;
+        public string _familyName = null;
+        public string _nameSuffix = null;
+        public string _nickname = null;
         
         public string NamePrefix { get { return _namePrefix; } }
         public string GivenName { get { return _givenName; } }

--- a/AppleAuthSampleProject/Assets/AppleAuthSample/MainMenu.cs
+++ b/AppleAuthSampleProject/Assets/AppleAuthSample/MainMenu.cs
@@ -180,7 +180,8 @@ public class MainMenu : MonoBehaviour
             error =>
             {
                 // If Quick Login fails, we should show the normal sign in with apple menu, to allow for a normal Sign In with apple
-                Debug.LogWarning("Quick Login Failed " + error.ToString());
+                var authorizationErrorCode = error.GetAuthorizationErrorCode();
+                Debug.LogWarning("Quick Login Failed " + authorizationErrorCode.ToString() + " " + error.ToString());
                 this.SetupLoginMenuForSignInWithApple();
             });
     }
@@ -199,7 +200,8 @@ public class MainMenu : MonoBehaviour
             },
             error =>
             {
-                Debug.LogWarning("Sign in with Apple failed " + error.ToString());
+                var authorizationErrorCode = error.GetAuthorizationErrorCode();
+                Debug.LogWarning("Sign in with Apple failed " + authorizationErrorCode.ToString() + " " + error.ToString());
                 this.SetupLoginMenuForSignInWithApple();
             });
     }

--- a/AppleAuthSampleProject/Assets/AppleAuthSample/MainMenu.cs
+++ b/AppleAuthSampleProject/Assets/AppleAuthSample/MainMenu.cs
@@ -1,5 +1,6 @@
 ﻿using AppleAuth;
 using AppleAuth.Enums;
+using AppleAuth.Extensions;
 using AppleAuth.Interfaces;
 using AppleAuth.Native;
 using UnityEngine;
@@ -152,7 +153,8 @@ public class MainMenu : MonoBehaviour
             },
             error =>
             {
-                Debug.LogWarning("Error while trying to get credential state " + error.ToString());
+                var authorizationErrorCode = error.GetAuthorizationErrorCode();
+                Debug.LogWarning("Error while trying to get credential state " + authorizationErrorCode.ToString() + " " + error.ToString());
                 this.SetupLoginMenuForSignInWithApple();
             });
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Changed
 - Makes the parsed classes `internal` to force the usage of the interfaces.
+- Minor changes for lower C# compatibility
+- `GetAuthorizationErrorCode` no longer returns a nullable reference type. If the error can't be obtained, it returns `Unknown` instead.
 
 ## [1.2.0] - 2020-05-16
 ### Added

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ this.appleAuthManager.LoginWithAppleId(
     error =>
     {
         // Something went wrong
+        var authorizationErrorCode = error.GetAuthorizationErrorCode();
     });
 ```
 


### PR DESCRIPTION
### Changed
- Minor changes for lower C# compatibility
- `GetAuthorizationErrorCode` no longer returns a nullable reference type. If the error can't be obtained, it returns `Unknown` instead.

Example to get the AuthorizationErrorCode
It sets default values for serializable classes to avoid unnecessary warnings