### PR TITLE
#72: Adds postprocessing helper for macOS

### DIFF
--- a/AppleAuth/Editor/AppleAuthMacosPostprocessorHelper.cs
+++ b/AppleAuth/Editor/AppleAuthMacosPostprocessorHelper.cs
@@ -36,6 +36,7 @@ namespace AppleAuth.Editor
                     "$1" + PlayerSettings.applicationIdentifier + "$3");
 
                 File.WriteAllText(macosAppleAuthManagerInfoPlistPath, modifiedMacosAppleAuthManagerInfoPlist);
+                Debug.Log("AppleAuthMacosPostprocessorHelper: Renamed MacOSAppleAuthManager.bundle bundle identifier from \"com.lupidan.MacOSAppleAuthManager\" -> \"" + PlayerSettings.applicationIdentifier + ".MacOSAppleAuthManager\"");
             }
             catch (Exception exception)
             {

--- a/AppleAuth/Editor/AppleAuthMacosPostprocessorHelper.cs
+++ b/AppleAuth/Editor/AppleAuthMacosPostprocessorHelper.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using UnityEditor;
+using UnityEngine;
+
+namespace AppleAuth.Editor
+{
+    public static class AppleAuthMacosPostprocessorHelper
+    {
+        /// <summary>
+        /// Use this script to change the bundle identifier of the plugin's library bundle to replace it with a personalized one for your product.
+        /// This should avoid CFBundleIdentifier Collision errors when uploading the app to the macOS App Store
+        /// </summary>
+        /// <remarks>Basically this should replace the plugin's bundle identifier from "com.lupidan.MacOSAppleAuthManager" to "{your.project.application.identifier}.MacOSAppleAuthManager"</remarks>
+        /// <param name="target">The current build target, so it's only executed when building for MacOS</param>
+        /// <param name="path">The path of the built .app file</param>
+        public static void FixManagerBundleIdentifier(BuildTarget target, string path)
+        {
+            if (target != BuildTarget.StandaloneOSX)
+            {
+                Debug.LogError("AppleAuthMacosPostprocessorHelper: FixManagerBundleIdentifier should only be called when building for macOS");
+                return;
+            }
+
+            const string bundleIdentifierPattern = @"(\<key\>CFBundleIdentifier\<\/key\>\s*\<string\>)(com\.lupidan)(\.MacOSAppleAuthManager\<\/string\>)";
+            const string macOSAppleAuthManagerInfoPlistRelativePath = "/Contents/Plugins/MacOSAppleAuthManager.bundle/Contents/Info.plist";
+
+            try
+            {
+                var macosAppleAuthManagerInfoPlistPath = path + macOSAppleAuthManagerInfoPlistRelativePath;
+                var macosAppleAuthManagerInfoPlist = File.ReadAllText(macosAppleAuthManagerInfoPlistPath);
+                var modifiedMacosAppleAuthManagerInfoPlist = Regex.Replace(
+                    macosAppleAuthManagerInfoPlist,
+                    bundleIdentifierPattern,
+                    "$1" + PlayerSettings.applicationIdentifier + "$3");
+
+                File.WriteAllText(macosAppleAuthManagerInfoPlistPath, modifiedMacosAppleAuthManagerInfoPlist);
+            }
+            catch (Exception exception)
+            {
+                Debug.LogError("AppleAuthMacosPostprocessorHelper: Error while fixing MacOSAppleAuthManager.bundle bundle identifier :: " + exception.Message);
+            }
+        }
+    }
+}

--- a/AppleAuth/Editor/AppleAuthMacosPostprocessorHelper.cs.meta
+++ b/AppleAuth/Editor/AppleAuthMacosPostprocessorHelper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bbc4b3c93b8146a5bce7197d43020b2c
+timeCreated: 1603011562

--- a/AppleAuthSampleProject/Assets/AppleAuthSample/Editor/SignInWithApplePostprocessor.cs
+++ b/AppleAuthSampleProject/Assets/AppleAuthSample/Editor/SignInWithApplePostprocessor.cs
@@ -1,9 +1,13 @@
 #if UNITY_IOS || UNITY_TVOS
+#define UNITY_XCODE_EXTENSIONS_AVAILABLE
+#endif
 
 using AppleAuth.Editor;
 using UnityEditor;
 using UnityEditor.Callbacks;
+#if UNITY_XCODE_EXTENSIONS_AVAILABLE
 using UnityEditor.iOS.Xcode;
+#endif
 
 namespace AppleAuthSample.Editor
 {
@@ -14,23 +18,27 @@ namespace AppleAuthSample.Editor
         [PostProcessBuild(CallOrder)]
         public static void OnPostProcessBuild(BuildTarget target, string path)
         {
-            if (target != BuildTarget.iOS && target != BuildTarget.tvOS)
-                return;
-            
-            var projectPath = PBXProject.GetPBXProjectPath(path);
-#if UNITY_2019_3_OR_NEWER
-            var project = new PBXProject();
-            project.ReadFromString(System.IO.File.ReadAllText(projectPath));
-            var manager = new ProjectCapabilityManager(projectPath, "Entitlements.entitlements", null, project.GetUnityMainTargetGuid());
-            manager.AddSignInWithAppleWithCompatibility(project.GetUnityFrameworkTargetGuid());
-            manager.WriteToFile();
-#else
-            var manager = new ProjectCapabilityManager(projectPath, "Entitlements.entitlements", PBXProject.GetUnityTargetName());
-            manager.AddSignInWithAppleWithCompatibility();
-            manager.WriteToFile();
-#endif
+            if (target == BuildTarget.iOS || target == BuildTarget.tvOS)
+            {
+                #if UNITY_XCODE_EXTENSIONS_AVAILABLE
+                    var projectPath = PBXProject.GetPBXProjectPath(path);
+                    #if UNITY_2019_3_OR_NEWER
+                        var project = new PBXProject();
+                        project.ReadFromString(System.IO.File.ReadAllText(projectPath));
+                        var manager = new ProjectCapabilityManager(projectPath, "Entitlements.entitlements", null, project.GetUnityMainTargetGuid());
+                        manager.AddSignInWithAppleWithCompatibility(project.GetUnityFrameworkTargetGuid());
+                        manager.WriteToFile();
+                    #else
+                        var manager = new ProjectCapabilityManager(projectPath, "Entitlements.entitlements", PBXProject.GetUnityTargetName());
+                        manager.AddSignInWithAppleWithCompatibility();
+                        manager.WriteToFile();
+                    #endif
+                #endif
+            }
+            else if (target == BuildTarget.StandaloneOSX)
+            {
+                AppleAuthMacosPostprocessorHelper.FixManagerBundleIdentifier(target, path);
+            }
         }
     }
 }
-
-#endif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Adds static class `AppleAuthMacosPostprocessorHelper`, so now there should always be an AppleAuth.Editor namespace independent of the current platform.
 - Adds static method to `AppleAuthMacosPostprocessorHelper`, `FixManagerBundleIdentifier` is a method to change the plugin's bundle identifier to a custom one based on the current project's application identifier. This should avoid CFBundleIdentifier collision errors when uploading to the MacOS App Store.
 
+### Changed
+- Updates sample code Postprocessor script to support the new recommended post processing for macOS builds
+
 ## [1.3.0] - 2020-07-18
 ### Added
 - Adds support to set the `State` when making a Login or a Quick Login request to sign in with Apple. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- Adds static class `AppleAuthMacosPostprocessorHelper`, so now there should always be an AppleAuth.Editor namespace independent of the current platform.
+- Adds static method to `AppleAuthMacosPostprocessorHelper`, `FixManagerBundleIdentifier` is a method to change the plugin's bundle identifier to a custom one based on the current project's application identifier. This should avoid CFBundleIdentifier collision errors when uploading to the MacOS App Store.
+
 ## [1.3.0] - 2020-07-18
 ### Added
 - Adds support to set the `State` when making a Login or a Quick Login request to sign in with Apple. 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ by **Daniel Lupiañez Casares**
     + [Why do I need to call Update manually on the AppleAuthManager instance?](#why-do-i-need-to-call-update-manually-on-the-appleAuthManager-instance)
     + [What deserialization library does it use by default?](#what-deserialization-library-does-it-use-by-default)
     + [Any way to get a refresh token after the first user authorization?](#any-way-to-get-a-refresh-token-after-the-first-user-authorization)
+    + [I am getting a CFBundleIdentifier Collision error when uploading my app to the macOS App Store](#i-am-getting-a-cfbundleIdentifier-collision-error-when-uploading-my-app-to-the-macos-app-store)
 
 ## Overview
 Sign in with Apple plugin to use with Unity 3D game engine.
@@ -217,10 +218,32 @@ The provided extension method uses reflection to integrate with the current tool
 ## Plugin setup (macOS)
 
 An unsigned precompiled `.bundle` file is available. It will be automatically included in your macOS builds.
+However that `.bundle` needs to be modified to avoid issues when uploading it to the MacOS App Store.
+
+In particular, the bundle identifier of that `.bundle` needs to be modified to a custom one.
+
+To automate the process, there is a helper method that will change the bundle identifier to one based on your project's application identifier.
+You should call this method on a Postprocess build script of your choice.
+
+```csharp
+using AppleAuth.Editor;
+
+public static class SignInWithApplePostprocessor
+{
+    [PostProcessBuild(1)]
+    public static void OnPostProcessBuild(BuildTarget target, string path)
+    {
+        if (target != BuildTarget.StandaloneOSX)
+            return;
+
+        AppleAuthMacosPostprocessorHelper.FixManagerBundleIdentifier(target, path);
+    }
+}
+```
 
 The Xcode project with the source code to generate a new bundle file is available at `MacOSAppleAuthManager/MacOSAppleAuthManager.xcodeproj`
 
-To support the feature, the app needs to be codesigned correctly, including the required entitlements. For more information regarding macOS codesign, please follow this [link](./docs/macOS_NOTES.md).
+To support the feature, **the app needs to be codesigned correctly**, including the required entitlements. For more information regarding macOS codesign, please follow this [link](./docs/macOS_NOTES.md).
 
 ## Implement Sign in With Apple
 
@@ -488,4 +511,15 @@ You can also implement your own deserialization by implementing an `IPayloadDese
 ### Any way to get a refresh token after the first user authorization?
 
 It seems currently is not possible to do so. You can read more details [here](https://github.com/lupidan/apple-signin-unity/issues/3)
+
+### I am getting a CFBundleIdentifier Collision error when uploading my app to the macOS App Store:
+
+If you are experiencing an error like this when uploading your macOS app to the App Store
+> The info.plist CFBundleIdentifier value 'com.lupidan.MacOSAppleAuthManager" of 'appname.app/Contents/Plugins/MacOSAppleAuthManager.bundle' is already in use by another application"
+
+It probably means that your [postprocess build script for macOS](#plugin-setup-macos) is not setup correctly.
+
+You should call `AppleAuthMacosPostprocessorHelper.FixManagerBundleIdentifier` to fix the plugin's bundle identifier to a custom one for your app.
+
+You can find more details about the bug [here](https://github.com/lupidan/apple-signin-unity/issues/72)
 


### PR DESCRIPTION
### Added
- Adds static class `AppleAuthMacosPostprocessorHelper`, so now there should always be an AppleAuth.Editor namespace independent of the current platform.
- Adds static method to `AppleAuthMacosPostprocessorHelper`, `FixManagerBundleIdentifier` is a method to change the plugin's bundle identifier to a custom one based on the current project's application identifier. This should avoid CFBundleIdentifier collision errors when uploading to the MacOS App Store.

### Changed
- Updates sample code Postprocessor script to support the new recommended post processing for macOS builds