### PR TITLE
Adds LoginOptions.None for LoginWithAppleId

### DIFF
--- a/AppleAuth/Enums/LoginOptions.cs
+++ b/AppleAuth/Enums/LoginOptions.cs
@@ -6,6 +6,11 @@ namespace AppleAuth.Enums
     public enum LoginOptions
     {
         /// <summary>
+        /// Empty scope. No full name or email
+        /// </summary>
+        None = 0,
+
+        /// <summary>
         /// A scope that includes the user’s full name.
         /// </summary>
         IncludeFullName = 1 << 0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Adds static class `AppleAuthMacosPostprocessorHelper`, so now there should always be an AppleAuth.Editor namespace independent of the current platform.
 - Adds static method to `AppleAuthMacosPostprocessorHelper`, `FixManagerBundleIdentifier` is a method to change the plugin's bundle identifier to a custom one based on the current project's application identifier. This should avoid CFBundleIdentifier collision errors when uploading to the MacOS App Store.
+- Adds enum value for `LoginOptions` to not request full name or email, `LoginOptions.None`.
 
 ### Changed
 - Updates sample code Postprocessor script to support the new recommended post processing for macOS builds

--- a/README.md
+++ b/README.md
@@ -485,11 +485,11 @@ If you want to test new account scenarios, you need to [revoke](#how-can-i-logou
 
 ### Is it possible to NOT request the user's email or full name?
 
-Yes! By passing `0` to the `LoginWithAppleId` method the user will not be asked for their email or full name.
+Yes, just provide `LoginOptions.None` when calling `LoginWithAppleId` and the user will not be asked for their email or full name.
 This will skip that entire login step and make it more smooth. It is recommended if the user's email or full name is not used.
 
 ```csharp
-appleAuthManager.LoginWithAppleId(0, credential => {}, error =>{});
+appleAuthManager.LoginWithAppleId(LoginOptions.None, credential => { ... }, error => { ... });
 ```
 
 ### Does the plugin use UnitySendMessage?


### PR DESCRIPTION
### Added
- Adds enum value for `LoginOptions` to not request full name or email, `LoginOptions.None`.