### PR TITLE
Add ToString override to AppleError

### DIFF
--- a/AppleAuth/Native/AppleError.cs
+++ b/AppleAuth/Native/AppleError.cs
@@ -32,5 +32,10 @@ namespace AppleAuth.Native
             
             SerializationTools.FixSerializationForArray(ref this._localizedRecoveryOptions);
         }
+
+        public override string ToString()
+        {
+            return $"Domain={_domain} Code={_code} Description={_localizedDescription}";
+        }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- Add `ToString` override to `AppleError`
+
 ## [1.4.2] - 2020-07-17
 ### Changed
 - Handles empty `NSPersonNameComponents` sent by Apple when not requesting a name, to be `nil` natively.


### PR DESCRIPTION
Currently, when a login error occurs, the following example code (taken from this repo's sample project):
```csharp
var authorizationErrorCode = error.GetAuthorizationErrorCode();
Debug.LogWarning("Sign in with Apple failed " + authorizationErrorCode.ToString() + " " + error.ToString());
```
Will result in something like the following being logged:
```
Sign in with Apple failed Unknown AppleAuth.Native.AppleError
```

------

`error.ToString()` just returning `AppleAuth.Native.AppleError` isn't super useful so this PR adds a ToString override so that instead something like the following would be logged instead:
```
Sign in with Apple failed Unknown Domain=com.apple.AuthenticationServices.AuthorizationError Code=1000 Description=The operation couldn’t be completed. (com.apple.AuthenticationServices.AuthorizationError error 1000.)
```