### PR TITLE
[1.5.0] Fixes package after migrating to new structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updates MacOS Xcode project file references to the new structure.
 - Removes `.meta` files inside the `MacOSAppleAuthManager.bundle`
 - Improves code that generates the `.unitypackage`
+- Updates sample project's code with proper namespaces.
 
 ## [1.4.4] - 2024-11-03
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Reworked package structure and folders to more closely resemble Unity guidelines for packages.
 - Updates MacOS Xcode project file references to the new structure.
 - Removes `.meta` files inside the `MacOSAppleAuthManager.bundle`
+- Improves code that generates the `.unitypackage`
 
 ## [1.4.4] - 2024-11-03
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## [Unreleased]
 ### Changed
 - Reworked package structure and folders to more closely resemble Unity guidelines for packages.
+- Updates MacOS Xcode project file references to the new structure.
+- Removes `.meta` files inside the `MacOSAppleAuthManager.bundle`
 
 ## [1.4.4] - 2024-11-03
 ### Changed

--- a/Runtime/Native/macOS/MacOSAppleAuthManager.bundle/Contents.meta
+++ b/Runtime/Native/macOS/MacOSAppleAuthManager.bundle/Contents.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 8801d15a10acc4f15ad37bb20de8d03a
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/Native/macOS/MacOSAppleAuthManager.bundle/Contents/Info.plist.meta
+++ b/Runtime/Native/macOS/MacOSAppleAuthManager.bundle/Contents/Info.plist.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 19e6dce0082b943b0a5fe3f3717b0feb
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/Native/macOS/MacOSAppleAuthManager.bundle/Contents/MacOS.meta
+++ b/Runtime/Native/macOS/MacOSAppleAuthManager.bundle/Contents/MacOS.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: d4bc59a6b606f48d384b6de4d83bb344
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/Native/macOS/MacOSAppleAuthManager.bundle/Contents/MacOS/MacOSAppleAuthManager.meta
+++ b/Runtime/Native/macOS/MacOSAppleAuthManager.bundle/Contents/MacOS/MacOSAppleAuthManager.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: fb5b02d9b484844eab64890f6362969b
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/SampleProject~/Assets/AppleAuthSample/GameMenuHandler.cs
+++ b/SampleProject~/Assets/AppleAuthSample/GameMenuHandler.cs
@@ -6,100 +6,103 @@ using System.Text;
 using UnityEngine;
 using UnityEngine.UI;
 
-[Serializable]
-public class GameMenuHandler
+namespace AppleAuthSample
 {
-    public GameObject Parent;
-    public Text AppleUserIdLabel;
-    public Text AppleUserCredentialLabel;
+    [Serializable]
+    public class GameMenuHandler
+    {
+        public GameObject Parent;
+        public Text AppleUserIdLabel;
+        public Text AppleUserCredentialLabel;
 
-    public void SetVisible(bool visible)
-    {
-        this.Parent.SetActive(visible);
-    }
-    
-    public void SetupAppleData(string appleUserId, ICredential receivedCredential)
-    {
-        this.AppleUserIdLabel.text = "Apple User ID: " + appleUserId;
-        if (receivedCredential == null)
+        public void SetVisible(bool visible)
         {
-            this.AppleUserCredentialLabel.text = "NO CREDENTIALS RECEIVED\nProbably credential status for " + appleUserId + "was Authorized";
-            return;
+            this.Parent.SetActive(visible);
         }
-
-        var appleIdCredential = receivedCredential as IAppleIDCredential;
-        var passwordCredential = receivedCredential as IPasswordCredential;
-        if (appleIdCredential != null)
+        
+        public void SetupAppleData(string appleUserId, ICredential receivedCredential)
         {
-            var stringBuilder = new StringBuilder();
-            stringBuilder.AppendLine("RECEIVED APPLE ID CREDENTIAL.\nYOU CAN LOGIN/CREATE A USER WITH THIS");
-            stringBuilder.AppendLine("<b>Username:</b> " + appleIdCredential.User);
-            stringBuilder.AppendLine("<b>Real user status:</b> " + appleIdCredential.RealUserStatus.ToString());
-
-            if (appleIdCredential.State != null)
-                stringBuilder.AppendLine("<b>State:</b> " + appleIdCredential.State);
-
-            if (appleIdCredential.IdentityToken != null)
+            this.AppleUserIdLabel.text = "Apple User ID: " + appleUserId;
+            if (receivedCredential == null)
             {
-                var identityToken = Encoding.UTF8.GetString(appleIdCredential.IdentityToken, 0, appleIdCredential.IdentityToken.Length);
-                stringBuilder.AppendLine("<b>Identity token (" + appleIdCredential.IdentityToken.Length + " bytes)</b>");
-                stringBuilder.AppendLine(identityToken.Substring(0, 45) + "...");
+                this.AppleUserCredentialLabel.text = "NO CREDENTIALS RECEIVED\nProbably credential status for " + appleUserId + "was Authorized";
+                return;
             }
 
-            if (appleIdCredential.AuthorizationCode != null)
+            var appleIdCredential = receivedCredential as IAppleIDCredential;
+            var passwordCredential = receivedCredential as IPasswordCredential;
+            if (appleIdCredential != null)
             {
-                var authorizationCode = Encoding.UTF8.GetString(appleIdCredential.AuthorizationCode, 0, appleIdCredential.AuthorizationCode.Length);
-                stringBuilder.AppendLine("<b>Authorization Code (" + appleIdCredential.AuthorizationCode.Length + " bytes)</b>");
-                stringBuilder.AppendLine(authorizationCode.Substring(0, 45) + "...");
-            }
+                var stringBuilder = new StringBuilder();
+                stringBuilder.AppendLine("RECEIVED APPLE ID CREDENTIAL.\nYOU CAN LOGIN/CREATE A USER WITH THIS");
+                stringBuilder.AppendLine("<b>Username:</b> " + appleIdCredential.User);
+                stringBuilder.AppendLine("<b>Real user status:</b> " + appleIdCredential.RealUserStatus.ToString());
 
-            if (appleIdCredential.AuthorizedScopes != null)
-                stringBuilder.AppendLine("<b>Authorized Scopes:</b> " + string.Join(", ", appleIdCredential.AuthorizedScopes));
+                if (appleIdCredential.State != null)
+                    stringBuilder.AppendLine("<b>State:</b> " + appleIdCredential.State);
 
-            if (appleIdCredential.Email != null)
-            {
-                stringBuilder.AppendLine();
-                stringBuilder.AppendLine("<b>EMAIL RECEIVED: YOU WILL ONLY SEE THIS ONCE PER SIGN UP. SEND THIS INFORMATION TO YOUR BACKEND!</b>");
-                stringBuilder.AppendLine("<b>You can test this again by revoking credentials in Settings</b>");
-                stringBuilder.AppendLine("<b>Email:</b> " + appleIdCredential.Email);
-            }
-
-            if (appleIdCredential.FullName != null)
-            {
-                var fullName = appleIdCredential.FullName;
-                stringBuilder.AppendLine();
-                stringBuilder.AppendLine("<b>NAME RECEIVED: YOU WILL ONLY SEE THIS ONCE PER SIGN UP. SEND THIS INFORMATION TO YOUR BACKEND!</b>");
-                stringBuilder.AppendLine("<b>You can test this again by revoking credentials in Settings</b>");
-                stringBuilder.AppendLine("<b>Name:</b> " + fullName.ToLocalizedString());
-                stringBuilder.AppendLine("<b>Name (Short):</b> " + fullName.ToLocalizedString(PersonNameFormatterStyle.Short));
-                stringBuilder.AppendLine("<b>Name (Medium):</b> " + fullName.ToLocalizedString(PersonNameFormatterStyle.Medium));
-                stringBuilder.AppendLine("<b>Name (Long):</b> " + fullName.ToLocalizedString(PersonNameFormatterStyle.Long));
-                stringBuilder.AppendLine("<b>Name (Abbreviated):</b> " + fullName.ToLocalizedString(PersonNameFormatterStyle.Abbreviated));
-
-                if (appleIdCredential.FullName.PhoneticRepresentation != null)
+                if (appleIdCredential.IdentityToken != null)
                 {
-                    var phoneticName = appleIdCredential.FullName.PhoneticRepresentation;
-                    stringBuilder.AppendLine("<b>Phonetic name:</b> " + phoneticName.ToLocalizedString());
-                    stringBuilder.AppendLine("<b>Phonetic name (Short):</b> " + phoneticName.ToLocalizedString(PersonNameFormatterStyle.Short));
-                    stringBuilder.AppendLine("<b>Phonetic name (Medium):</b> " + phoneticName.ToLocalizedString(PersonNameFormatterStyle.Medium));
-                    stringBuilder.AppendLine("<b>Phonetic name (Long):</b> " + phoneticName.ToLocalizedString(PersonNameFormatterStyle.Long));
-                    stringBuilder.AppendLine("<b>Phonetic name (Abbreviated):</b> " + phoneticName.ToLocalizedString(PersonNameFormatterStyle.Abbreviated));
+                    var identityToken = Encoding.UTF8.GetString(appleIdCredential.IdentityToken, 0, appleIdCredential.IdentityToken.Length);
+                    stringBuilder.AppendLine("<b>Identity token (" + appleIdCredential.IdentityToken.Length + " bytes)</b>");
+                    stringBuilder.AppendLine(identityToken.Substring(0, 45) + "...");
                 }
-            }
 
-            this.AppleUserCredentialLabel.text = stringBuilder.ToString();
-        }
-        else if (passwordCredential != null)
-        {
-            var stringBuilder = new StringBuilder();
-            stringBuilder.AppendLine("USERNAME/PASSWORD RECEIVED (iCloud?)");
-            stringBuilder.AppendLine("<b>Username:</b> " + passwordCredential.User);
-            stringBuilder.AppendLine("<b>Password:</b> " + passwordCredential.Password);
-            this.AppleUserCredentialLabel.text = stringBuilder.ToString();
-        }
-        else
-        {
-            this.AppleUserCredentialLabel.text = "Unknown credentials for user " + receivedCredential.User;
+                if (appleIdCredential.AuthorizationCode != null)
+                {
+                    var authorizationCode = Encoding.UTF8.GetString(appleIdCredential.AuthorizationCode, 0, appleIdCredential.AuthorizationCode.Length);
+                    stringBuilder.AppendLine("<b>Authorization Code (" + appleIdCredential.AuthorizationCode.Length + " bytes)</b>");
+                    stringBuilder.AppendLine(authorizationCode.Substring(0, 45) + "...");
+                }
+
+                if (appleIdCredential.AuthorizedScopes != null)
+                    stringBuilder.AppendLine("<b>Authorized Scopes:</b> " + string.Join(", ", appleIdCredential.AuthorizedScopes));
+
+                if (appleIdCredential.Email != null)
+                {
+                    stringBuilder.AppendLine();
+                    stringBuilder.AppendLine("<b>EMAIL RECEIVED: YOU WILL ONLY SEE THIS ONCE PER SIGN UP. SEND THIS INFORMATION TO YOUR BACKEND!</b>");
+                    stringBuilder.AppendLine("<b>You can test this again by revoking credentials in Settings</b>");
+                    stringBuilder.AppendLine("<b>Email:</b> " + appleIdCredential.Email);
+                }
+
+                if (appleIdCredential.FullName != null)
+                {
+                    var fullName = appleIdCredential.FullName;
+                    stringBuilder.AppendLine();
+                    stringBuilder.AppendLine("<b>NAME RECEIVED: YOU WILL ONLY SEE THIS ONCE PER SIGN UP. SEND THIS INFORMATION TO YOUR BACKEND!</b>");
+                    stringBuilder.AppendLine("<b>You can test this again by revoking credentials in Settings</b>");
+                    stringBuilder.AppendLine("<b>Name:</b> " + fullName.ToLocalizedString());
+                    stringBuilder.AppendLine("<b>Name (Short):</b> " + fullName.ToLocalizedString(PersonNameFormatterStyle.Short));
+                    stringBuilder.AppendLine("<b>Name (Medium):</b> " + fullName.ToLocalizedString(PersonNameFormatterStyle.Medium));
+                    stringBuilder.AppendLine("<b>Name (Long):</b> " + fullName.ToLocalizedString(PersonNameFormatterStyle.Long));
+                    stringBuilder.AppendLine("<b>Name (Abbreviated):</b> " + fullName.ToLocalizedString(PersonNameFormatterStyle.Abbreviated));
+
+                    if (appleIdCredential.FullName.PhoneticRepresentation != null)
+                    {
+                        var phoneticName = appleIdCredential.FullName.PhoneticRepresentation;
+                        stringBuilder.AppendLine("<b>Phonetic name:</b> " + phoneticName.ToLocalizedString());
+                        stringBuilder.AppendLine("<b>Phonetic name (Short):</b> " + phoneticName.ToLocalizedString(PersonNameFormatterStyle.Short));
+                        stringBuilder.AppendLine("<b>Phonetic name (Medium):</b> " + phoneticName.ToLocalizedString(PersonNameFormatterStyle.Medium));
+                        stringBuilder.AppendLine("<b>Phonetic name (Long):</b> " + phoneticName.ToLocalizedString(PersonNameFormatterStyle.Long));
+                        stringBuilder.AppendLine("<b>Phonetic name (Abbreviated):</b> " + phoneticName.ToLocalizedString(PersonNameFormatterStyle.Abbreviated));
+                    }
+                }
+
+                this.AppleUserCredentialLabel.text = stringBuilder.ToString();
+            }
+            else if (passwordCredential != null)
+            {
+                var stringBuilder = new StringBuilder();
+                stringBuilder.AppendLine("USERNAME/PASSWORD RECEIVED (iCloud?)");
+                stringBuilder.AppendLine("<b>Username:</b> " + passwordCredential.User);
+                stringBuilder.AppendLine("<b>Password:</b> " + passwordCredential.Password);
+                this.AppleUserCredentialLabel.text = stringBuilder.ToString();
+            }
+            else
+            {
+                this.AppleUserCredentialLabel.text = "Unknown credentials for user " + receivedCredential.User;
+            }
         }
     }
 }

--- a/SampleProject~/Assets/AppleAuthSample/LoginMenuHandler.cs
+++ b/SampleProject~/Assets/AppleAuthSample/LoginMenuHandler.cs
@@ -2,38 +2,41 @@ using System;
 using UnityEngine;
 using UnityEngine.UI;
 
-[Serializable]
-public class LoginMenuHandler
+namespace AppleAuthSample
 {
-    public GameObject Parent;
-    public GameObject SignInWithAppleParent;
-    public Button SignInWithAppleButton;
-    public GameObject LoadingMessageParent;
-    public Transform LoadingIconTransform;
-    public Text LoadingMessageLabel;
-
-    public void SetVisible(bool visible)
+    [Serializable]
+    public class LoginMenuHandler
     {
-        this.Parent.SetActive(visible);
-    }
+        public GameObject Parent;
+        public GameObject SignInWithAppleParent;
+        public Button SignInWithAppleButton;
+        public GameObject LoadingMessageParent;
+        public Transform LoadingIconTransform;
+        public Text LoadingMessageLabel;
 
-    public void SetLoadingMessage(bool visible,  string message)
-    {
-        this.LoadingMessageParent.SetActive(visible);
-        this.LoadingMessageLabel.text = message;
-    }
+        public void SetVisible(bool visible)
+        {
+            this.Parent.SetActive(visible);
+        }
 
-    public void SetSignInWithAppleButton(bool visible, bool enabled)
-    {
-        this.SignInWithAppleParent.SetActive(visible);
-        this.SignInWithAppleButton.enabled = enabled;
-    }
+        public void SetLoadingMessage(bool visible,  string message)
+        {
+            this.LoadingMessageParent.SetActive(visible);
+            this.LoadingMessageLabel.text = message;
+        }
 
-    public void UpdateLoadingMessage(float deltaTime)
-    {
-        if (!this.LoadingMessageParent.activeSelf)
-            return;
+        public void SetSignInWithAppleButton(bool visible, bool enabled)
+        {
+            this.SignInWithAppleParent.SetActive(visible);
+            this.SignInWithAppleButton.enabled = enabled;
+        }
+
+        public void UpdateLoadingMessage(float deltaTime)
+        {
+            if (!this.LoadingMessageParent.activeSelf)
+                return;
         
-        this.LoadingIconTransform.Rotate(0.0f, 0.0f, -360.0f * deltaTime);
+            this.LoadingIconTransform.Rotate(0.0f, 0.0f, -360.0f * deltaTime);
+        }
     }
 }

--- a/SampleProject~/Assets/AppleAuthSample/MainMenu.cs
+++ b/SampleProject~/Assets/AppleAuthSample/MainMenu.cs
@@ -5,204 +5,207 @@ using AppleAuth.Interfaces;
 using AppleAuth.Native;
 using UnityEngine;
 
-public class MainMenu : MonoBehaviour
+namespace AppleAuthSample
 {
-    private const string AppleUserIdKey = "AppleUserId";
-    
-    private IAppleAuthManager _appleAuthManager;
-
-    public LoginMenuHandler LoginMenu;
-    public GameMenuHandler GameMenu;
-
-    private void Start()
+    public class MainMenu : MonoBehaviour
     {
-        // If the current platform is supported
-        if (AppleAuthManager.IsCurrentPlatformSupported)
-        {
-            // Creates a default JSON deserializer, to transform JSON Native responses to C# instances
-            var deserializer = new PayloadDeserializer();
-            // Creates an Apple Authentication manager with the deserializer
-            this._appleAuthManager = new AppleAuthManager(deserializer);    
-        }
-
-        this.InitializeLoginMenu();
-    }
-
-    private void Update()
-    {
-        // Updates the AppleAuthManager instance to execute
-        // pending callbacks inside Unity's execution loop
-        if (this._appleAuthManager != null)
-        {
-            this._appleAuthManager.Update();
-        }
+        private const string AppleUserIdKey = "AppleUserId";
         
-        this.LoginMenu.UpdateLoadingMessage(Time.deltaTime);
-    }
+        private IAppleAuthManager _appleAuthManager;
 
-    public void SignInWithAppleButtonPressed()
-    {
-        this.SetupLoginMenuForAppleSignIn();
-        this.SignInWithApple();
-    }
+        public LoginMenuHandler LoginMenu;
+        public GameMenuHandler GameMenu;
 
-    private void InitializeLoginMenu()
-    {
-        this.LoginMenu.SetVisible(visible: true);
-        this.GameMenu.SetVisible(visible: false);
-        
-        // Check if the current platform supports Sign In With Apple
-        if (this._appleAuthManager == null)
+        private void Start()
         {
-            this.SetupLoginMenuForUnsupportedPlatform();
-            return;
-        }
-        
-        // If at any point we receive a credentials revoked notification, we delete the stored User ID, and go back to login
-        this._appleAuthManager.SetCredentialsRevokedCallback(result =>
-        {
-            Debug.Log("Received revoked callback " + result);
-            this.SetupLoginMenuForSignInWithApple();
-            PlayerPrefs.DeleteKey(AppleUserIdKey);
-        });
-
-        // If we have an Apple User Id available, get the credential status for it
-        if (PlayerPrefs.HasKey(AppleUserIdKey))
-        {
-            var storedAppleUserId = PlayerPrefs.GetString(AppleUserIdKey);
-            this.SetupLoginMenuForCheckingCredentials();
-            this.CheckCredentialStatusForUserId(storedAppleUserId);
-        }
-        // If we do not have an stored Apple User Id, attempt a quick login
-        else
-        {
-            this.SetupLoginMenuForQuickLoginAttempt();
-            this.AttemptQuickLogin();
-        }
-    }
-
-    private void SetupLoginMenuForUnsupportedPlatform()
-    {
-        this.LoginMenu.SetVisible(visible: true);
-        this.GameMenu.SetVisible(visible: false);
-        this.LoginMenu.SetSignInWithAppleButton(visible: false, enabled: false);
-        this.LoginMenu.SetLoadingMessage(visible: true, message: "Unsupported platform");
-    }
-    
-    private void SetupLoginMenuForSignInWithApple()
-    {
-        this.LoginMenu.SetVisible(visible: true);
-        this.GameMenu.SetVisible(visible: false);
-        this.LoginMenu.SetSignInWithAppleButton(visible: true, enabled: true);
-        this.LoginMenu.SetLoadingMessage(visible: false, message: string.Empty);
-    }
-    
-    private void SetupLoginMenuForCheckingCredentials()
-    {
-        this.LoginMenu.SetVisible(visible: true);
-        this.GameMenu.SetVisible(visible: false);
-        this.LoginMenu.SetSignInWithAppleButton(visible: true, enabled: false);
-        this.LoginMenu.SetLoadingMessage(visible: true, message: "Checking Apple Credentials");
-    }
-    
-    private void SetupLoginMenuForQuickLoginAttempt()
-    {
-        this.LoginMenu.SetVisible(visible: true);
-        this.GameMenu.SetVisible(visible: false);
-        this.LoginMenu.SetSignInWithAppleButton(visible: true, enabled: false);
-        this.LoginMenu.SetLoadingMessage(visible: true, message: "Attempting Quick Login");
-    }
-    
-    private void SetupLoginMenuForAppleSignIn()
-    {
-        this.LoginMenu.SetVisible(visible: true);
-        this.GameMenu.SetVisible(visible: false);
-        this.LoginMenu.SetSignInWithAppleButton(visible: true, enabled: false);
-        this.LoginMenu.SetLoadingMessage(visible: true, message: "Signing In with Apple");
-    }
-    
-    private void SetupGameMenu(string appleUserId, ICredential credential)
-    {
-        this.LoginMenu.SetVisible(visible: false);
-        this.GameMenu.SetVisible(visible: true);
-        this.GameMenu.SetupAppleData(appleUserId, credential);
-    }
-
-    private void CheckCredentialStatusForUserId(string appleUserId)
-    {
-        // If there is an apple ID available, we should check the credential state
-        this._appleAuthManager.GetCredentialState(
-            appleUserId,
-            state =>
+            // If the current platform is supported
+            if (AppleAuthManager.IsCurrentPlatformSupported)
             {
-                switch (state)
+                // Creates a default JSON deserializer, to transform JSON Native responses to C# instances
+                var deserializer = new PayloadDeserializer();
+                // Creates an Apple Authentication manager with the deserializer
+                this._appleAuthManager = new AppleAuthManager(deserializer);    
+            }
+
+            this.InitializeLoginMenu();
+        }
+
+        private void Update()
+        {
+            // Updates the AppleAuthManager instance to execute
+            // pending callbacks inside Unity's execution loop
+            if (this._appleAuthManager != null)
+            {
+                this._appleAuthManager.Update();
+            }
+            
+            this.LoginMenu.UpdateLoadingMessage(Time.deltaTime);
+        }
+
+        public void SignInWithAppleButtonPressed()
+        {
+            this.SetupLoginMenuForAppleSignIn();
+            this.SignInWithApple();
+        }
+
+        private void InitializeLoginMenu()
+        {
+            this.LoginMenu.SetVisible(visible: true);
+            this.GameMenu.SetVisible(visible: false);
+            
+            // Check if the current platform supports Sign In With Apple
+            if (this._appleAuthManager == null)
+            {
+                this.SetupLoginMenuForUnsupportedPlatform();
+                return;
+            }
+            
+            // If at any point we receive a credentials revoked notification, we delete the stored User ID, and go back to login
+            this._appleAuthManager.SetCredentialsRevokedCallback(result =>
+            {
+                Debug.Log("Received revoked callback " + result);
+                this.SetupLoginMenuForSignInWithApple();
+                PlayerPrefs.DeleteKey(AppleUserIdKey);
+            });
+
+            // If we have an Apple User Id available, get the credential status for it
+            if (PlayerPrefs.HasKey(AppleUserIdKey))
+            {
+                var storedAppleUserId = PlayerPrefs.GetString(AppleUserIdKey);
+                this.SetupLoginMenuForCheckingCredentials();
+                this.CheckCredentialStatusForUserId(storedAppleUserId);
+            }
+            // If we do not have an stored Apple User Id, attempt a quick login
+            else
+            {
+                this.SetupLoginMenuForQuickLoginAttempt();
+                this.AttemptQuickLogin();
+            }
+        }
+
+        private void SetupLoginMenuForUnsupportedPlatform()
+        {
+            this.LoginMenu.SetVisible(visible: true);
+            this.GameMenu.SetVisible(visible: false);
+            this.LoginMenu.SetSignInWithAppleButton(visible: false, enabled: false);
+            this.LoginMenu.SetLoadingMessage(visible: true, message: "Unsupported platform");
+        }
+        
+        private void SetupLoginMenuForSignInWithApple()
+        {
+            this.LoginMenu.SetVisible(visible: true);
+            this.GameMenu.SetVisible(visible: false);
+            this.LoginMenu.SetSignInWithAppleButton(visible: true, enabled: true);
+            this.LoginMenu.SetLoadingMessage(visible: false, message: string.Empty);
+        }
+        
+        private void SetupLoginMenuForCheckingCredentials()
+        {
+            this.LoginMenu.SetVisible(visible: true);
+            this.GameMenu.SetVisible(visible: false);
+            this.LoginMenu.SetSignInWithAppleButton(visible: true, enabled: false);
+            this.LoginMenu.SetLoadingMessage(visible: true, message: "Checking Apple Credentials");
+        }
+        
+        private void SetupLoginMenuForQuickLoginAttempt()
+        {
+            this.LoginMenu.SetVisible(visible: true);
+            this.GameMenu.SetVisible(visible: false);
+            this.LoginMenu.SetSignInWithAppleButton(visible: true, enabled: false);
+            this.LoginMenu.SetLoadingMessage(visible: true, message: "Attempting Quick Login");
+        }
+        
+        private void SetupLoginMenuForAppleSignIn()
+        {
+            this.LoginMenu.SetVisible(visible: true);
+            this.GameMenu.SetVisible(visible: false);
+            this.LoginMenu.SetSignInWithAppleButton(visible: true, enabled: false);
+            this.LoginMenu.SetLoadingMessage(visible: true, message: "Signing In with Apple");
+        }
+        
+        private void SetupGameMenu(string appleUserId, ICredential credential)
+        {
+            this.LoginMenu.SetVisible(visible: false);
+            this.GameMenu.SetVisible(visible: true);
+            this.GameMenu.SetupAppleData(appleUserId, credential);
+        }
+
+        private void CheckCredentialStatusForUserId(string appleUserId)
+        {
+            // If there is an apple ID available, we should check the credential state
+            this._appleAuthManager.GetCredentialState(
+                appleUserId,
+                state =>
                 {
-                    // If it's authorized, login with that user id
-                    case CredentialState.Authorized:
-                        this.SetupGameMenu(appleUserId, null);
-                        return;
-                    
-                    // If it was revoked, or not found, we need a new sign in with apple attempt
-                    // Discard previous apple user id
-                    case CredentialState.Revoked:
-                    case CredentialState.NotFound:
-                        this.SetupLoginMenuForSignInWithApple();
-                        PlayerPrefs.DeleteKey(AppleUserIdKey);
-                        return;
-                }
-            },
-            error =>
-            {
-                var authorizationErrorCode = error.GetAuthorizationErrorCode();
-                Debug.LogWarning("Error while trying to get credential state " + authorizationErrorCode.ToString() + " " + error.ToString());
-                this.SetupLoginMenuForSignInWithApple();
-            });
-    }
-    
-    private void AttemptQuickLogin()
-    {
-        var quickLoginArgs = new AppleAuthQuickLoginArgs();
-        
-        // Quick login should succeed if the credential was authorized before and not revoked
-        this._appleAuthManager.QuickLogin(
-            quickLoginArgs,
-            credential =>
-            {
-                // If it's an Apple credential, save the user ID, for later logins
-                var appleIdCredential = credential as IAppleIDCredential;
-                if (appleIdCredential != null)
+                    switch (state)
+                    {
+                        // If it's authorized, login with that user id
+                        case CredentialState.Authorized:
+                            this.SetupGameMenu(appleUserId, null);
+                            return;
+                        
+                        // If it was revoked, or not found, we need a new sign in with apple attempt
+                        // Discard previous apple user id
+                        case CredentialState.Revoked:
+                        case CredentialState.NotFound:
+                            this.SetupLoginMenuForSignInWithApple();
+                            PlayerPrefs.DeleteKey(AppleUserIdKey);
+                            return;
+                    }
+                },
+                error =>
                 {
-                    PlayerPrefs.SetString(AppleUserIdKey, credential.User);    
-                }
-
-                this.SetupGameMenu(credential.User, credential);
-            },
-            error =>
-            {
-                // If Quick Login fails, we should show the normal sign in with apple menu, to allow for a normal Sign In with apple
-                var authorizationErrorCode = error.GetAuthorizationErrorCode();
-                Debug.LogWarning("Quick Login Failed " + authorizationErrorCode.ToString() + " " + error.ToString());
-                this.SetupLoginMenuForSignInWithApple();
-            });
-    }
-    
-    private void SignInWithApple()
-    {
-        var loginArgs = new AppleAuthLoginArgs(LoginOptions.IncludeEmail | LoginOptions.IncludeFullName);
+                    var authorizationErrorCode = error.GetAuthorizationErrorCode();
+                    Debug.LogWarning("Error while trying to get credential state " + authorizationErrorCode.ToString() + " " + error.ToString());
+                    this.SetupLoginMenuForSignInWithApple();
+                });
+        }
         
-        this._appleAuthManager.LoginWithAppleId(
-            loginArgs,
-            credential =>
-            {
-                // If a sign in with apple succeeds, we should have obtained the credential with the user id, name, and email, save it
-                PlayerPrefs.SetString(AppleUserIdKey, credential.User);
-                this.SetupGameMenu(credential.User, credential);
-            },
-            error =>
-            {
-                var authorizationErrorCode = error.GetAuthorizationErrorCode();
-                Debug.LogWarning("Sign in with Apple failed " + authorizationErrorCode.ToString() + " " + error.ToString());
-                this.SetupLoginMenuForSignInWithApple();
-            });
+        private void AttemptQuickLogin()
+        {
+            var quickLoginArgs = new AppleAuthQuickLoginArgs();
+            
+            // Quick login should succeed if the credential was authorized before and not revoked
+            this._appleAuthManager.QuickLogin(
+                quickLoginArgs,
+                credential =>
+                {
+                    // If it's an Apple credential, save the user ID, for later logins
+                    var appleIdCredential = credential as IAppleIDCredential;
+                    if (appleIdCredential != null)
+                    {
+                        PlayerPrefs.SetString(AppleUserIdKey, credential.User);    
+                    }
+
+                    this.SetupGameMenu(credential.User, credential);
+                },
+                error =>
+                {
+                    // If Quick Login fails, we should show the normal sign in with apple menu, to allow for a normal Sign In with apple
+                    var authorizationErrorCode = error.GetAuthorizationErrorCode();
+                    Debug.LogWarning("Quick Login Failed " + authorizationErrorCode.ToString() + " " + error.ToString());
+                    this.SetupLoginMenuForSignInWithApple();
+                });
+        }
+        
+        private void SignInWithApple()
+        {
+            var loginArgs = new AppleAuthLoginArgs(LoginOptions.IncludeEmail | LoginOptions.IncludeFullName);
+            
+            this._appleAuthManager.LoginWithAppleId(
+                loginArgs,
+                credential =>
+                {
+                    // If a sign in with apple succeeds, we should have obtained the credential with the user id, name, and email, save it
+                    PlayerPrefs.SetString(AppleUserIdKey, credential.User);
+                    this.SetupGameMenu(credential.User, credential);
+                },
+                error =>
+                {
+                    var authorizationErrorCode = error.GetAuthorizationErrorCode();
+                    Debug.LogWarning("Sign in with Apple failed " + authorizationErrorCode.ToString() + " " + error.ToString());
+                    this.SetupLoginMenuForSignInWithApple();
+                });
+        }
     }
 }

--- a/SampleProject~/Assets/UnityPackageGeneration/Editor/ActionDisposable.cs
+++ b/SampleProject~/Assets/UnityPackageGeneration/Editor/ActionDisposable.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace UnityPackageGeneration.Editor
+{
+    internal class ActionDisposable : IDisposable
+    {
+        private readonly Action _action;
+
+        public ActionDisposable(Action action)
+        {
+            _action = action;
+        }
+
+        public void Dispose()
+        {
+            _action.Invoke();
+        }
+    }
+}

--- a/SampleProject~/Assets/UnityPackageGeneration/Editor/ActionDisposable.cs
+++ b/SampleProject~/Assets/UnityPackageGeneration/Editor/ActionDisposable.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace UnityPackageGeneration.Editor
+namespace AppleAuthSample.UnityPackageGeneration.Editor
 {
     internal class ActionDisposable : IDisposable
     {

--- a/SampleProject~/Assets/UnityPackageGeneration/Editor/ActionDisposable.cs.meta
+++ b/SampleProject~/Assets/UnityPackageGeneration/Editor/ActionDisposable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8f675872b308474392d4a5ffb304a0de
+timeCreated: 1740847119

--- a/SampleProject~/Assets/UnityPackageGeneration/Editor/CreateUnityPackage.cs
+++ b/SampleProject~/Assets/UnityPackageGeneration/Editor/CreateUnityPackage.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using UnityEditor;
 using UnityEngine;
 
@@ -12,6 +13,12 @@ namespace AppleAuthSample.UnityPackageGeneration.Editor
             var originalFolder = Path.Combine("Packages", "com.lupidan.apple-signin-unity");
             var destinationFolder = Path.Combine("Assets", "AppleAuth");
             var assetsToMove = new[] {"docs", "Editor", "Runtime"};
+            var unityPackagePath = Path.GetFullPath(
+                Path.Combine(
+                    Application.dataPath,
+                    "..",
+                    "..",
+                    "AppleSignInUnity.unitypackage"));
 
             using (PackageAssetMover.MoveFiles(originalFolder, destinationFolder, assetsToMove))
             {
@@ -21,11 +28,7 @@ namespace AppleAuthSample.UnityPackageGeneration.Editor
                     Path.Combine("Assets", "AppleAuthSample")
                 };
 
-                var unityPackagePath = Path.Combine(
-                    Application.dataPath,
-                    "..",
-                    "..",
-                    "AppleSignInUnity.unitypackage");
+                
                 var flags = ExportPackageOptions.Recurse;
                 
                 AssetDatabase.ExportPackage(
@@ -33,6 +36,17 @@ namespace AppleAuthSample.UnityPackageGeneration.Editor
                     unityPackagePath, 
                     flags);
             }
+
+            var deleted = AssetDatabase.DeleteAsset(destinationFolder);
+            if (!deleted)
+            {
+                throw new Exception($"[{nameof(CreateUnityPackage)}] Couldn't delete {destinationFolder}");
+            }
+
+            EditorUtility.DisplayDialog(
+                "Unity package generated",
+                $"Unity package generated successfully at {unityPackagePath}.",
+                "OK");
         }
     }
 }

--- a/SampleProject~/Assets/UnityPackageGeneration/Editor/CreateUnityPackage.cs
+++ b/SampleProject~/Assets/UnityPackageGeneration/Editor/CreateUnityPackage.cs
@@ -1,72 +1,38 @@
-﻿using System;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using UnityEditor;
+using UnityEngine;
 
 namespace UnityPackageGeneration.Editor
 {
     public static class CreateUnityPackage
     {
-        private class FileCopyEntry
-        {
-            public readonly string OriginalFilepath;
-            public readonly string DestinationFilepath;
-
-            public FileCopyEntry(string originalFilepath, string destinationFilepath)
-            {
-                OriginalFilepath = originalFilepath;
-                DestinationFilepath = destinationFilepath;
-            }
-        }
-        
         [MenuItem("Tools/Generate Apple Auth Unity Package")]
         public static void GenerateUnityPackage()
         {
-            var assetsFolderPath = Directory.GetCurrentDirectory() + "/Assets/";
-            var rootFolderPath = Directory.GetCurrentDirectory() + "/../";
-            var packageFolderPath = Directory.GetCurrentDirectory() + "/../AppleAuth/";
-            
-            var rootFolder = new Uri(rootFolderPath, UriKind.Absolute);
-            var packageFolder = new Uri(packageFolderPath, UriKind.Absolute);
+            var originalFolder = Path.Combine("Packages", "com.lupidan.apple-signin-unity");
+            var destinationFolder = Path.Combine("Assets", "AppleAuth");
+            var assetsToMove = new[] {"docs", "Editor", "Runtime"};
 
-            var allFiles = Directory.GetFiles(
-                packageFolder.AbsolutePath,
-                "*",
-                SearchOption.AllDirectories);
-            
-            var pluginFiles = allFiles
-                .Where(absoluteFilepath => !absoluteFilepath.EndsWith(".meta"))
-                .Select(absoluteFilepath =>
+            using (PackageAssetMover.MoveFiles(originalFolder, destinationFolder, assetsToMove))
+            {
+                var assetPathNames = new[]
                 {
-                    var originalFileUri = new Uri(absoluteFilepath);
-                    var relativeUri = rootFolder.MakeRelativeUri(originalFileUri);
-                    var destinationFileUri = new Uri(
-                        assetsFolderPath + relativeUri.ToString(),
-                        UriKind.Absolute);
-                    
-                    return new FileCopyEntry(absoluteFilepath, destinationFileUri.AbsolutePath);
-                })
-                .ToList();
+                    Path.Combine("Assets", "AppleAuth"),
+                    Path.Combine("Assets", "AppleAuthSample")
+                };
+
+                var unityPackagePath = Path.Combine(
+                    Application.dataPath,
+                    "..",
+                    "..",
+                    "AppleSignInUnity.unitypackage");
+                var flags = ExportPackageOptions.Recurse;
                 
-            pluginFiles
-                .ForEach(entry =>
-                {
-                    var directory = Path.GetDirectoryName(entry.DestinationFilepath);
-                    if (directory != null && !Directory.Exists(directory))
-                        Directory.CreateDirectory(directory);
-
-                    FileUtil.CopyFileOrDirectory(entry.OriginalFilepath, entry.DestinationFilepath);
-                });
-            
-            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
-            AssetDatabase.ExportPackage(
-                new [] {"Assets/AppleAuth", "Assets/AppleAuthSample"},
-                "AppleSignInUnity.unitypackage", 
-                ExportPackageOptions.Recurse);
-
-            Directory.Delete(assetsFolderPath + "/AppleAuth/", true);
-            FileUtil.DeleteFileOrDirectory(assetsFolderPath + "/AppleAuth.meta");
-            AssetDatabase.Refresh();
+                AssetDatabase.ExportPackage(
+                    assetPathNames,
+                    unityPackagePath, 
+                    flags);
+            }
         }
     }
 }

--- a/SampleProject~/Assets/UnityPackageGeneration/Editor/CreateUnityPackage.cs
+++ b/SampleProject~/Assets/UnityPackageGeneration/Editor/CreateUnityPackage.cs
@@ -2,7 +2,7 @@
 using UnityEditor;
 using UnityEngine;
 
-namespace UnityPackageGeneration.Editor
+namespace AppleAuthSample.UnityPackageGeneration.Editor
 {
     public static class CreateUnityPackage
     {

--- a/SampleProject~/Assets/UnityPackageGeneration/Editor/PackageAssetMover.cs
+++ b/SampleProject~/Assets/UnityPackageGeneration/Editor/PackageAssetMover.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using UnityEditor;
 
-namespace UnityPackageGeneration.Editor
+namespace AppleAuthSample.UnityPackageGeneration.Editor
 {
     internal class PackageAssetMover
     {

--- a/SampleProject~/Assets/UnityPackageGeneration/Editor/PackageAssetMover.cs
+++ b/SampleProject~/Assets/UnityPackageGeneration/Editor/PackageAssetMover.cs
@@ -41,14 +41,14 @@ namespace AppleAuthSample.UnityPackageGeneration.Editor
                 if (string.IsNullOrEmpty(parentFolder))
                 {
                     throw new Exception(
-                        $"[{nameof(CreateUnityPackage)}] Can't determine parent folder from {destinationFolder}");
+                        $"[{nameof(PackageAssetMover)}] Can't determine parent folder from {destinationFolder}");
                 }
 
                 var newFolderName = Path.GetFileName(destinationFolder);
                 if (string.IsNullOrEmpty(newFolderName))
                 {
                     throw new Exception(
-                        $"[{nameof(CreateUnityPackage)}] Can't determine folder name from {destinationFolder}");
+                        $"[{nameof(PackageAssetMover)}] Can't determine folder name from {destinationFolder}");
                 }
 
                 var directoryGuid = AssetDatabase.CreateFolder(
@@ -57,7 +57,7 @@ namespace AppleAuthSample.UnityPackageGeneration.Editor
 
                 if (string.IsNullOrEmpty(directoryGuid))
                 {
-                    throw new Exception($"[{nameof(CreateUnityPackage)}] Couldn't create {destinationFolder}");
+                    throw new Exception($"[{nameof(PackageAssetMover)}] Couldn't create {destinationFolder}");
                 }
             }
 
@@ -70,7 +70,7 @@ namespace AppleAuthSample.UnityPackageGeneration.Editor
                 if (!string.IsNullOrEmpty(error))
                 {
                     throw new Exception(
-                        $"[{nameof(CreateUnityPackage)}] Couldn't move {assetToMove} from {originalFolder} to {destinationFolder} due to:\n{error}");
+                        $"[{nameof(PackageAssetMover)}] Couldn't move {assetToMove} from {originalFolder} to {destinationFolder} due to:\n{error}");
                 }
             }
         }

--- a/SampleProject~/Assets/UnityPackageGeneration/Editor/PackageAssetMover.cs
+++ b/SampleProject~/Assets/UnityPackageGeneration/Editor/PackageAssetMover.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using UnityEditor;
+
+namespace UnityPackageGeneration.Editor
+{
+    internal class PackageAssetMover
+    {
+        public static IDisposable MoveFiles(
+            string originalFolder,
+            string destinationFolder,
+            params string[] assetsToMove)
+        {
+            var packageAssetMover = new PackageAssetMover(originalFolder, destinationFolder, assetsToMove);
+            packageAssetMover.MoveToDestination();
+            return new ActionDisposable(() => packageAssetMover.MoveBackToOrigin());
+        }
+
+        private readonly string _originalFolder;
+        private readonly string _destinationFolder;
+        private readonly string[] _assetsToMove;
+
+        private PackageAssetMover(
+            string originalFolder,
+            string destinationFolder,
+            params string[] assetsToMove)
+        {
+            _originalFolder = originalFolder;
+            _destinationFolder = destinationFolder;
+            _assetsToMove = assetsToMove;
+        }
+
+        private void MoveToDestination() => Move(_originalFolder, _destinationFolder);
+        private void MoveBackToOrigin() => Move(_destinationFolder, _originalFolder);
+
+        private void Move(string originalFolder, string destinationFolder)
+        {
+            if (!AssetDatabase.IsValidFolder(destinationFolder))
+            {
+                var parentFolder = Path.GetDirectoryName(destinationFolder);
+                if (string.IsNullOrEmpty(parentFolder))
+                {
+                    throw new Exception(
+                        $"[{nameof(CreateUnityPackage)}] Can't determine parent folder from {destinationFolder}");
+                }
+
+                var newFolderName = Path.GetFileName(destinationFolder);
+                if (string.IsNullOrEmpty(newFolderName))
+                {
+                    throw new Exception(
+                        $"[{nameof(CreateUnityPackage)}] Can't determine folder name from {destinationFolder}");
+                }
+
+                var directoryGuid = AssetDatabase.CreateFolder(
+                    parentFolder,
+                    newFolderName);
+
+                if (string.IsNullOrEmpty(directoryGuid))
+                {
+                    throw new Exception($"[{nameof(CreateUnityPackage)}] Couldn't create {destinationFolder}");
+                }
+            }
+
+            foreach (var assetToMove in _assetsToMove)
+            {
+                var error = AssetDatabase.MoveAsset(
+                    Path.Combine(originalFolder, assetToMove),
+                    Path.Combine(destinationFolder, assetToMove));
+
+                if (!string.IsNullOrEmpty(error))
+                {
+                    throw new Exception(
+                        $"[{nameof(CreateUnityPackage)}] Couldn't move {assetToMove} from {originalFolder} to {destinationFolder} due to:\n{error}");
+                }
+            }
+        }
+    }
+}

--- a/SampleProject~/Assets/UnityPackageGeneration/Editor/PackageAssetMover.cs.meta
+++ b/SampleProject~/Assets/UnityPackageGeneration/Editor/PackageAssetMover.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6a3377b696614a7eb12947580d415f78
+timeCreated: 1740847006

--- a/Xcode~/MacOSAppleAuthManager.xcodeproj/project.pbxproj
+++ b/Xcode~/MacOSAppleAuthManager.xcodeproj/project.pbxproj
@@ -7,21 +7,21 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		900B92F22454CC0B006DABD8 /* AppleAuthManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 900B92ED2454CC0B006DABD8 /* AppleAuthManager.m */; };
-		900B92F32454CC0B006DABD8 /* AppleAuthSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 900B92EF2454CC0B006DABD8 /* AppleAuthSerializer.m */; };
-		900B92F42454CC0B006DABD8 /* PersonNameComponentsFormatting.m in Sources */ = {isa = PBXBuildFile; fileRef = 900B92F02454CC0B006DABD8 /* PersonNameComponentsFormatting.m */; };
 		900B92F82454DD51006DABD8 /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 900B92F72454DD51006DABD8 /* AuthenticationServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C22C43C22D7361990050EBAD /* PersonNameComponentsFormatting.m in Sources */ = {isa = PBXBuildFile; fileRef = C22C43C12D7361990050EBAD /* PersonNameComponentsFormatting.m */; };
+		C22C43C32D7361990050EBAD /* AppleAuthManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C22C43BE2D7361990050EBAD /* AppleAuthManager.m */; };
+		C22C43C42D7361990050EBAD /* AppleAuthSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = C22C43C02D7361990050EBAD /* AppleAuthSerializer.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		900B92E42454CBAD006DABD8 /* MacOSAppleAuthManager.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MacOSAppleAuthManager.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		900B92E72454CBAD006DABD8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		900B92ED2454CC0B006DABD8 /* AppleAuthManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppleAuthManager.m; path = ../../AppleAuth/Native/iOS/AppleAuthManager.m; sourceTree = "<group>"; };
-		900B92EE2454CC0B006DABD8 /* AppleAuthManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppleAuthManager.h; path = ../../AppleAuth/Native/iOS/AppleAuthManager.h; sourceTree = "<group>"; };
-		900B92EF2454CC0B006DABD8 /* AppleAuthSerializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppleAuthSerializer.m; path = ../../AppleAuth/Native/iOS/AppleAuthSerializer.m; sourceTree = "<group>"; };
-		900B92F02454CC0B006DABD8 /* PersonNameComponentsFormatting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PersonNameComponentsFormatting.m; path = ../../AppleAuth/Native/iOS/PersonNameComponentsFormatting.m; sourceTree = "<group>"; };
-		900B92F12454CC0B006DABD8 /* AppleAuthSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppleAuthSerializer.h; path = ../../AppleAuth/Native/iOS/AppleAuthSerializer.h; sourceTree = "<group>"; };
 		900B92F72454DD51006DABD8 /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
+		C22C43BD2D7361990050EBAD /* AppleAuthManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppleAuthManager.h; path = ../Runtime/Native/iOS/AppleAuthManager.h; sourceTree = SOURCE_ROOT; };
+		C22C43BE2D7361990050EBAD /* AppleAuthManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppleAuthManager.m; path = ../Runtime/Native/iOS/AppleAuthManager.m; sourceTree = SOURCE_ROOT; };
+		C22C43BF2D7361990050EBAD /* AppleAuthSerializer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppleAuthSerializer.h; path = ../Runtime/Native/iOS/AppleAuthSerializer.h; sourceTree = SOURCE_ROOT; };
+		C22C43C02D7361990050EBAD /* AppleAuthSerializer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppleAuthSerializer.m; path = ../Runtime/Native/iOS/AppleAuthSerializer.m; sourceTree = SOURCE_ROOT; };
+		C22C43C12D7361990050EBAD /* PersonNameComponentsFormatting.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PersonNameComponentsFormatting.m; path = ../Runtime/Native/iOS/PersonNameComponentsFormatting.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,11 +56,11 @@
 		900B92E62454CBAD006DABD8 /* MacOSAppleAuthManager */ = {
 			isa = PBXGroup;
 			children = (
-				900B92EE2454CC0B006DABD8 /* AppleAuthManager.h */,
-				900B92ED2454CC0B006DABD8 /* AppleAuthManager.m */,
-				900B92F12454CC0B006DABD8 /* AppleAuthSerializer.h */,
-				900B92EF2454CC0B006DABD8 /* AppleAuthSerializer.m */,
-				900B92F02454CC0B006DABD8 /* PersonNameComponentsFormatting.m */,
+				C22C43BD2D7361990050EBAD /* AppleAuthManager.h */,
+				C22C43BE2D7361990050EBAD /* AppleAuthManager.m */,
+				C22C43BF2D7361990050EBAD /* AppleAuthSerializer.h */,
+				C22C43C02D7361990050EBAD /* AppleAuthSerializer.m */,
+				C22C43C12D7361990050EBAD /* PersonNameComponentsFormatting.m */,
 				900B92E72454CBAD006DABD8 /* Info.plist */,
 			);
 			path = MacOSAppleAuthManager;
@@ -153,7 +153,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "rm -r $SOURCE_ROOT/../AppleAuth/Native/macOS/$FULL_PRODUCT_NAME\ncp -r $CODESIGNING_FOLDER_PATH $SOURCE_ROOT/../AppleAuth/Native/macOS/$FULL_PRODUCT_NAME\n";
+			shellScript = "rm -r $SOURCE_ROOT/../Runtime/Native/macOS/$FULL_PRODUCT_NAME\ncp -r $CODESIGNING_FOLDER_PATH $SOURCE_ROOT/../Runtime/Native/macOS/$FULL_PRODUCT_NAME\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -162,9 +162,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				900B92F42454CC0B006DABD8 /* PersonNameComponentsFormatting.m in Sources */,
-				900B92F32454CC0B006DABD8 /* AppleAuthSerializer.m in Sources */,
-				900B92F22454CC0B006DABD8 /* AppleAuthManager.m in Sources */,
+				C22C43C22D7361990050EBAD /* PersonNameComponentsFormatting.m in Sources */,
+				C22C43C32D7361990050EBAD /* AppleAuthManager.m in Sources */,
+				C22C43C42D7361990050EBAD /* AppleAuthSerializer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
### Changed
- Updates MacOS Xcode project file references to the new structure.
- Removes `.meta` files inside the `MacOSAppleAuthManager.bundle`
- Improves code that generates the `.unitypackage`
- Updates sample project's code with proper namespaces.