### PR TITLE
[1.5.0] Better detection of macOS Bundle using the helper method

### DIFF
--- a/.github/workflows/build-and-check.yml
+++ b/.github/workflows/build-and-check.yml
@@ -10,15 +10,13 @@ jobs:
       matrix:
         unity-version-and-platform:
           - "6000.0.40f1,StandaloneOSX"
-          - "6000.0.40f1,iOS"
-
           - "2022.3.59f1,StandaloneOSX"
-          - "2022.3.59f1,iOS"
-
-          - "2021.3.45f1,StandaloneOSX"
-          - "2021.3.45f1,iOS"
-
           - "2020.3.48f1,StandaloneOSX"
+          - "2021.3.45f1,StandaloneOSX"
+
+          - "6000.0.40f1,iOS"
+          - "2022.3.59f1,iOS"
+          - "2021.3.45f1,iOS"
           - "2020.3.48f1,iOS"
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## [1.5.0] - TBD
 ### Changed
 - Reworked package structure and folders to more closely resemble Unity guidelines for packages.
-- Updated macOS helper method in `AppleAuthMacosPostprocessorHelper.FixManagerBundleIdentifier` for a more robust code and execution.
+- Updated macOS helper method in `AppleAuthMacosPostprocessorHelper.FixManagerBundleIdentifier` to easier locate the bundle for both `.app` and `xcodeproj` generation.
 - Updates MacOS Xcode project file references to the new structure.
 - Improves code that generates the `.unitypackage`.
 - Updates sample project's code with proper namespaces.

--- a/Editor/AppleAuthMacosPostprocessorHelper.cs
+++ b/Editor/AppleAuthMacosPostprocessorHelper.cs
@@ -55,7 +55,12 @@ namespace AppleAuth.Editor
         {
             const string bundleName = "MacOSAppleAuthManager.bundle";
             
-            var possibleRootPaths = new List<string> {path};
+            var possibleRootPaths = new List<string>();
+            if (Directory.Exists(path))
+            {
+                possibleRootPaths.Add(path);
+            }
+            
             if (Directory.Exists($"{path}.app"))
             {
                 possibleRootPaths.Add($"{path}.app");

--- a/Editor/AppleAuthMacosPostprocessorHelper.cs
+++ b/Editor/AppleAuthMacosPostprocessorHelper.cs
@@ -51,23 +51,36 @@ namespace AppleAuth.Editor
 
         private static string GetInfoPlistPath(string path)
         {
-            var possibleInfoPlistPaths = new[]
-            {
-                Path.Combine(path, "Contents", "Plugins", "MacOSAppleAuthManager.bundle", "Contents", "Info.plist"),
-                Path.Combine(path, "Contents", "PlugIns", "MacOSAppleAuthManager.bundle", "Contents", "Info.plist"),
-                Path.Combine($"{path}.app", "Contents", "Plugins", "MacOSAppleAuthManager.bundle", "Contents", "Info.plist"),
-                Path.Combine($"{path}.app", "Contents", "PlugIns", "MacOSAppleAuthManager.bundle", "Contents", "Info.plist"),
-            };
+            var bundleDirectories = Directory.GetDirectories(
+                path,
+                "MacOSAppleAuthManager.bundle",
+                SearchOption.AllDirectories);
 
-            foreach (var possibleInfoPlistPath in possibleInfoPlistPaths)
+            if (bundleDirectories.Length == 0)
             {
-                if (File.Exists(possibleInfoPlistPath))
-                {
-                    return possibleInfoPlistPath;
-                }
+                throw new Exception(GetMessage("Can't locate any MacOSAppleAuthManager.bundle"));
+            }
+
+            if (bundleDirectories.Length > 1)
+            {
+                var allPaths = string.Join("\n", bundleDirectories);
+                throw new Exception(GetMessage($"Located multiple MacOSAppleAuthManager.bundle!\n{allPaths}"));
             }
             
-            throw new Exception(GetMessage("Can't locate MacOSAppleAuthManager.bundle info plist"));
+            var bundlePath = bundleDirectories[0];
+            var infoPlistPath = Path.Combine(
+                bundlePath,
+                "Contents",
+                "Info.plist");
+
+            if (!File.Exists(infoPlistPath))
+            {
+                throw new Exception(GetMessage("Can't locate MacOSAppleAuthManager's Info.plist"));
+            }
+            
+            Debug.Log(GetMessage($"Located Info.plist at {infoPlistPath}"));
+            
+            return infoPlistPath;
         }
     }
 }

--- a/Editor/AppleAuthMacosPostprocessorHelper.cs
+++ b/Editor/AppleAuthMacosPostprocessorHelper.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
@@ -51,23 +53,35 @@ namespace AppleAuth.Editor
 
         private static string GetInfoPlistPath(string path)
         {
-            var bundleDirectories = Directory.GetDirectories(
-                path,
-                "MacOSAppleAuthManager.bundle",
-                SearchOption.AllDirectories);
+            const string bundleName = "MacOSAppleAuthManager.bundle";
+            
+            var possibleRootPaths = new List<string> {path};
+            if (Directory.Exists($"{path}.app"))
+            {
+                possibleRootPaths.Add($"{path}.app");
+            }
+
+            var bundleDirectories = possibleRootPaths
+                .SelectMany(possibleRootPath => Directory.GetDirectories(
+                    possibleRootPath,
+                    bundleName,
+                    SearchOption.AllDirectories))
+                .ToArray();
 
             if (bundleDirectories.Length == 0)
             {
-                throw new Exception(GetMessage("Can't locate any MacOSAppleAuthManager.bundle"));
+                throw new Exception(GetMessage($"Can't locate any {bundleName}"));
             }
 
             if (bundleDirectories.Length > 1)
             {
                 var allPaths = string.Join("\n", bundleDirectories);
-                throw new Exception(GetMessage($"Located multiple MacOSAppleAuthManager.bundle!\n{allPaths}"));
+                throw new Exception(GetMessage($"Located multiple {bundleName}!\n{allPaths}"));
             }
             
             var bundlePath = bundleDirectories[0];
+            Debug.Log(GetMessage($"Located {bundleName} at {bundlePath}"));
+            
             var infoPlistPath = Path.Combine(
                 bundlePath,
                 "Contents",


### PR DESCRIPTION
### Changed
- Updated macOS helper method in `AppleAuthMacosPostprocessorHelper.FixManagerBundleIdentifier` to easier locate the bundle for both `.app` and `xcodeproj` generation.